### PR TITLE
BugFix: Handle visiting page schedule breaks when no conference is created

### DIFF
--- a/traveller/modules/y/view.py
+++ b/traveller/modules/y/view.py
@@ -129,8 +129,9 @@ def schedule(year):
     conf = Conf.query.filter(
         Conf.year == year
         ).first()
-    if conf.schedule is None:
-        conf.schedule = Schedule()
+    if conf is not None:
+        if conf.schedule is None:
+            conf.schedule = Schedule()
 
     weekmap = {
         0: 'Monday',


### PR DESCRIPTION
This fixes issue #42 