### PR TITLE
Remove "login successful" flash each time viewing dashboard.

### DIFF
--- a/traveller/modules/box__default/auth/forms.py
+++ b/traveller/modules/box__default/auth/forms.py
@@ -13,14 +13,16 @@ from .models import User
 
 class LoginForm(FlaskForm):
     email = EmailField(
-        "email",
+        "Email",
         [DataRequired(), Email(message=("Not a valid email address."))],
-        render_kw={"class": "form-control", "autocomplete": "off"},
+        render_kw={"class": "form-control", "autocomplete": "off", 
+        "placeholder": "e.g. johndoe@example.com"},
     )
     password = PasswordField(
         "Password",
         [DataRequired()],
-        render_kw={"class": "form-control", "autocomplete": "off"},
+        render_kw={"class": "form-control", "autocomplete": "off", 
+        "placeholder": "enter your password"},
     )
 
 

--- a/traveller/modules/box__default/auth/templates/auth/blocks/login_form.html
+++ b/traveller/modules/box__default/auth/templates/auth/blocks/login_form.html
@@ -1,31 +1,39 @@
 
 <p class="h2">Login</p>
-<div class="input-group mb-3">
+
+<div class="form-group mt-3 mb-0 text-left">
+    {{ form.email.label }}
+</div>
+<div class="input-group mb-1">
     <div class="input-group-prepend">
         <span class="input-group-text"><i class="fa fa-id-card"></i></span>
     </div>
     {{ form.email() }}
-    {% if form.email.errors %}
-        <ul class="errors">
-            {% for error in form.email.errors %}
-	            <li>{{ error }}</li>
-            {% endfor %}
-        </ul>
-    {% endif %}
 </div>
-<div class="input-group mb-3">
+{% if form.email.errors %}
+    <div class="text-left">
+        {% for error in form.email.errors %}
+            <small class="text-danger">{{ error }}</small>
+        {% endfor %}
+    </div>
+{% endif %}
+
+<div class="form-group mt-3 mb-0 text-left">
+    {{ form.password.label }}
+</div>
+<div class="input-group mb-1">
     <div class="input-group-prepend">
         <span class="input-group-text"><i class="fa fa-key"></i></span>
     </div>
     {{ form.password() }}
-    {% if form.password.errors %}
-        <ul class="errors">
-            {% for error in form.password.errors %}
-	            <li>{{ error }}</li>
-            {% endfor %}
-        </ul>
-    {% endif %}
 </div>
+{% if form.password.errors %}
+    <div class="text-left">
+        {% for error in form.password.errors %}
+            <small class="text-danger">{{ error }}</small>
+        {% endfor %}
+    </div>
+{% endif %}
 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
 <input
@@ -33,4 +41,4 @@
     name="next"
     value="{{ request.args.get('next', '') }}"
 />
-<input type="submit" name="" value="submit" class="btn btn-info">
+<input type="submit" name="" value="submit" class="btn btn-info mt-3">

--- a/traveller/modules/box__default/auth/templates/auth/login.html
+++ b/traveller/modules/box__default/auth/templates/auth/login.html
@@ -27,6 +27,9 @@
         .all_inactive {
             display: none;
         }
+        label{
+            margin-bottom: 0 !important;
+        }
     </style>  
 
 {% endblock %}

--- a/traveller/modules/box__default/auth/tests/test_auth_functional.py
+++ b/traveller/modules/box__default/auth/tests/test_auth_functional.py
@@ -262,7 +262,7 @@ class TestAuthEndpoints:
 
         response.status_code == 200
         assert request.path == url_for("auth.login")
-        assert b"please check your user id and password" in response.data
+        assert b"Please check your email and password" in response.data
 
     def test_valid_dashboard_login(self, test_client, admin_user):
         response = test_client.post(

--- a/traveller/modules/box__default/dashboard/view.py
+++ b/traveller/modules/box__default/dashboard/view.py
@@ -67,6 +67,5 @@ def index():
                     module_info = json.load(f)
                     all_info[folder] = module_info
 
-    context["all_info"] = all_info
-    flash(notify_success("You have logged in successfully!"))
+    context["all_info"] = all_info    
     return render_template("dashboard/index.html", **context)

--- a/traveller/modules/cfp/view.py
+++ b/traveller/modules/cfp/view.py
@@ -72,6 +72,9 @@ def add_talk(year):
 @login_required
 def edit_talk(year, talk_id):
     talk = Talk.query.get(talk_id)
+    if talk is None:
+        alert_danger('Invalid talk.')
+        return mhelp.redirect_url('y.cfp', year=year)
     if ((current_user in talk.author_list.authors) or current_user.is_admin):
         
         form = SubmitTalkForm(obj=talk)
@@ -110,6 +113,9 @@ def rate_talk(year, talk_id, score, talk_num_):
         if score not in [0, 1, 2]:
             return '---'
         talk = Talk.query.get(talk_id)
+        if talk is None:
+            alert_danger('Invalid talk.')
+            return mhelp.redirect_url('www.index')
         reviewers = [sl.reviewer for sl in talk.score_lists]
         if current_user not in reviewers:
             
@@ -144,6 +150,9 @@ def final_talk_action(year, talk_id):
             return render_template('conftheme/{}/parts/final_talk_action.html'.format(year), **context)
         elif request.method == 'POST':
             talk = Talk.query.get(talk_id)
+            if talk is None:
+                alert_danger('Invalid talk.')
+                return mhelp.redirect_url('y.cfp', year=year)
             form = AdminTalkForm(obj=talk)
             form.populate_obj(talk)
             if not form.validate():
@@ -169,6 +178,12 @@ def delete_talk(year, talk_id):
     if talk.submitter_id != current_user.id or not current_user.is_admin:
         alert_danger("You don't have access to delete talk.")
         if redirect_page == 'leaderboard':
+            return mhelp.redirect_url('y.leaderboard', year=year) 
+        else: return mhelp.redirect_url('y.profile', year=year)
+    
+    if talk is None:
+        if redirect_page == 'leaderboard':
+            alert_danger('Invalid talk.')
             return mhelp.redirect_url('y.leaderboard', year=year) 
         else: return mhelp.redirect_url('y.profile', year=year)
 

--- a/traveller/modules/conf/view.py
+++ b/traveller/modules/conf/view.py
@@ -55,6 +55,8 @@ def add():
 def edit(conf_id):
     form = ConfForm()
     conf = Conf.query.get(conf_id)
+    if conf is None:
+        return mhelp.redirect_url('conf.dashboard')
     form = ConfForm(obj=conf)
     form.populate_obj(conf)
     form.validate()
@@ -66,6 +68,8 @@ def edit(conf_id):
 @module_blueprint.route("/<conf_id>/delete", methods=["POST"])
 def delete(conf_id):
     conf = Conf.query.get(conf_id)
+    if conf is None:
+        return mhelp.redirect_url('conf.dashboard')
     conf.delete()
     return mhelp.redirect_url('conf.dashboard')
 
@@ -73,6 +77,8 @@ def delete(conf_id):
 @module_blueprint.route("/<conf_id>/reviewers/update", methods=["POST"])
 def update_reviewers(conf_id):
     conf = Conf.query.get(conf_id)
+    if conf is None:
+        return mhelp.redirect_url('conf.dashboard')
     if conf.reviewer_list is None:
         conf.reviewer_list = ReviewerList()
     conf.reviewer_list.reviewers = []

--- a/traveller/modules/schedule/view.py
+++ b/traveller/modules/schedule/view.py
@@ -67,6 +67,9 @@ def add_day(year):
 def add_activity(year, day_id, act_type):
     if act_type == 'normal_activity':
         day = Day.query.get(day_id)
+        if day is None:
+            alert_danger('Invalid day.')
+            return mhelp.redirect_url('y.schedule', year=year)
         form = NormalActivityForm()
 
         if not form.validate():
@@ -83,6 +86,9 @@ def add_activity(year, day_id, act_type):
         day.update()
     elif act_type == 'talk':
         day = Day.query.get(day_id)
+        if day is None:
+            alert_danger('Invalid day.')
+            return mhelp.redirect_url('y.schedule', year=year)
         form = TalkActivityForm()
 
         if not form.validate():
@@ -115,6 +121,9 @@ def edit_activity(year, act_id, act_type):
             alert_danger("End time should be greater than start date")
             return mhelp.redirect_url('y.schedule', year=year)
         activity = Activity.query.get(act_id)
+        if activity is None:
+            alert_danger('Invalid activity.')
+            return mhelp.redirect_url('y.schedule', year=year)
         form.populate_obj(activity)
         activity.update()
     elif act_type == 'talk':
@@ -127,6 +136,9 @@ def edit_activity(year, act_id, act_type):
             alert_danger("End date should be greater than start date")
             return mhelp.redirect_url('y.schedule', year=year)
         activity = Activity.query.get(act_id)
+        if activity is None:
+            alert_danger('Invalid activity.')
+            return mhelp.redirect_url('y.schedule', year=year)
         activity.start_time = form.start_time.data
         activity.end_time = form.end_time.data
         activity.talk_id = form.talks.data.id if form.talks.data is not None else None
@@ -140,6 +152,9 @@ def edit_day(year, day_id):
     if current_user.is_admin:
         day = Day.query.get(day_id)
 
+        if day is None:
+            alert_danger('Invalid day.')
+            return mhelp.redirect_url('y.schedule', year=year)
         form = DayForm(obj=day)
         form.populate_obj(day)
         if not form.validate():
@@ -160,6 +175,9 @@ def delete_activity(year, act_id):
         alert_danger("You don't have access to delete activity.")
         return mhelp.redirect_url('y.schedule', year=year)
     activity = Activity.query.get(act_id)
+    if activity is None:
+        alert_danger('Invalid activity.')
+        return mhelp.redirect_url('y.schedule', year=year)
     activity.delete()
     return mhelp.redirect_url('y.schedule', year=year)
 
@@ -172,6 +190,9 @@ def delete_day(year, day_id):
         return mhelp.redirect_url('y.schedule', year=year)
 
     day = Day.query.get(day_id)
+    if day is None:
+        alert_danger('Invalid day.')
+        return mhelp.redirect_url('y.schedule', year=year)
     day.delete()
     alert_success('Day deleted!')
     return mhelp.redirect_url('y.schedule', year=year)


### PR DESCRIPTION
This PR fixes the following:

- [x] Issue #176 
- [x] Improves accessibility for the login form and handles form field errors
- [x] Ensures server doesn't crash if a user tries to edit conf, day, activity, or talk which doesn't exist. For example, if a talk_id doesn't exist and a user tries to edit it, we send a warning.
- [x] Ensures server doesn't crash if a user tries to delete conf, day, activity, or talk which doesn't exist. For example, if a day_id doesn't exist and a user tries to delete it, we send a warning.
- [x] Ensure logout redirects to the login form. Also if a user logs in again, the next query parameter is applied effectively