### PR TITLE
Feature: Improvements to the scheduling page.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,5 @@ Werkzeug==1.0.1
 WTForms==2.3.3
 WTForms-Alchemy==0.17.0
 WTForms-Components==0.10.5
-tzdata
-backports.zoneinfo
+tzdata==2021.5
+backports.zoneinfo==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,4 +36,4 @@ WTForms==2.3.3
 WTForms-Alchemy==0.17.0
 WTForms-Components==0.10.5
 tzdata
-ics
+backports.zoneinfo

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,5 @@ Werkzeug==1.0.1
 WTForms==2.3.3
 WTForms-Alchemy==0.17.0
 WTForms-Components==0.10.5
+tzdata
+ics

--- a/traveller/app.py
+++ b/traveller/app.py
@@ -15,6 +15,7 @@ from flask_admin import AdminIndexView
 from flask_admin import expose
 from flask_admin.menu import MenuLink
 from flask_uploads import configure_uploads
+from jinja2.filters import evalcontextfilter
 
 from modules.box__default.settings.helpers import get_setting
 from modules.box__default.settings.models import Settings
@@ -212,6 +213,7 @@ def create_app(config_name):
                 jinja2.FileSystemLoader([front_theme_dir, back_theme_dir]),
             ]
         )
+    
         app.jinja_loader = my_loader
 
     #
@@ -238,6 +240,12 @@ with open(os.path.join(base_path, "config.json")) as f:
     config_json = json.load(f)
 environment = config_json["environment"]
 app = create_app(environment)
+
+@app.template_filter()
+@evalcontextfilter
+def get_enum(eval_ctx, value):
+    # Custom filter to return enumerated iterable
+    return enumerate(value)
 
 
 if __name__ == "__main__":

--- a/traveller/conftest.py
+++ b/traveller/conftest.py
@@ -10,6 +10,7 @@ import pathlib
 import pytest
 import datetime
 from flask import url_for
+from jinja2.filters import evalcontextfilter
 
 from app import create_app
 from init import db as _db
@@ -64,10 +65,17 @@ def admin_user():
     return user
 
 
+@evalcontextfilter
+def get_enum(eval_ctx, value):
+    # Custom filter to return enumerated iterable
+    return enumerate(value)
+
 @pytest.fixture(scope="session")
 def flask_app():
     flask_app = create_app("testing")
+    flask_app.add_template_filter(get_enum,name="get_enum")
     return flask_app
+
 
 
 @pytest.fixture(scope="session")

--- a/traveller/init.py
+++ b/traveller/init.py
@@ -3,6 +3,10 @@ All initialisations like db = SQLAlchemy in this file
 """
 
 import os
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 from flask_login import LoginManager
 from flask_marshmallow import Marshmallow
@@ -11,6 +15,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_uploads import IMAGES
 from flask_uploads import UploadSet
 from flask_mailman import Mail
+
 
 root_path = os.path.dirname(os.path.abspath(__file__)) # don't remove
 static_path = os.path.join(root_path, "static") # don't remove
@@ -23,6 +28,7 @@ login_manager = LoginManager()
 migrate = Migrate()
 mail = Mail()
 images = UploadSet("images", IMAGES, default_dest=lambda app: static_path + '/images_uploads')
+tzinfo, conf_time_zone = ZoneInfo, ZoneInfo("UTC")
 
 from flask_wtf import FlaskForm
 from wtforms_alchemy import model_form_factory
@@ -33,3 +39,4 @@ class ModelForm(BaseModelForm):
     @classmethod
     def get_session(self):
         return db.session
+

--- a/traveller/modules/cfp/forms.py
+++ b/traveller/modules/cfp/forms.py
@@ -5,39 +5,39 @@ from init import ModelForm
 class SubmitTalkForm(ModelForm):
     class Meta:
         model = Talk
-        exclude = ['accepted', 'slug', 'submitter_id', 'year']
+        exclude = ['accepted', 'slug', 'submitter_id', 'year', 'duration']
         field_args = {
             'title': {
                 'render_kw': {
                     'autocomplete': 'off',
                     'maxlength': 200,
-                'class': 'border-1 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring  ease-linear transition-all duration-150'
+                'class': 'border-1 px-3 mb-4 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring  ease-linear transition-all duration-150'
                 }
             },
             'description': {
                 'render_kw': {
                     'cols': 80,
                     'maxlength': 3000,
-                    'class': 'border-1 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring  ease-linear transition-all duration-150'
+                    'class': 'border-1 mb-4 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring  ease-linear transition-all duration-150'
                 }
             },
             'summary': {
                 'render_kw': {
                     'cols': 80,
                     'maxlength': 300,
-                    'class': 'border-1 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring  ease-linear transition-all duration-150'
+                    'class': 'border-1 mb-4 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring  ease-linear transition-all duration-150'
                 }
             },
             'notes': {
                 'render_kw': {
                     'cols': 80,
                     'maxlength': 200,
-                    'class': 'border-1 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring  ease-linear transition-all duration-150'
+                    'class': 'border-1 mb-4 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring  ease-linear transition-all duration-150'
                 }
             },
             'level': {
                 'render_kw': {
-                    'class': 'border-1 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring  ease-linear transition-all duration-150'
+                    'class': 'border-1 mb-4 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring  ease-linear transition-all duration-150'
                 }
             }
         }
@@ -46,7 +46,7 @@ class SubmitTalkForm(ModelForm):
 class AdminTalkForm(ModelForm):
     class Meta:
         model = Talk
-        exclude = ['submitter_id', 'year']
+        exclude = ['submitter_id', 'year', 'duration']
         field_args = {
             'title': {
                 'render_kw': {

--- a/traveller/modules/cfp/view.py
+++ b/traveller/modules/cfp/view.py
@@ -2,6 +2,8 @@
 Manages CFP. Adds talk to conferences
 Lets reviewers review talks
 '''
+from datetime import timedelta
+
 from shopyo.api.module import ModuleHelp
 from modules.box__default.auth.models import User
 from modules.conf.models import Conf
@@ -54,6 +56,12 @@ def add_talk(year):
     talk.submitter_id = current_user.id
     talk.year = year
     talk.talk_conference = conf
+
+    start_time, end_time = request.form.get('start_time', "09:00"), request.form.get('end_time', "18:00")
+    start_time = timedelta(hours=int(start_time.split(':', 1)[0]), minutes=int(start_time.split(':', 1)[1]))
+    end_time = timedelta(hours=int(end_time.split(':', 1)[0]), minutes=int(end_time.split(':', 1)[1]))
+    duration = end_time - start_time
+    talk.duration = duration.seconds
 
     co_authors_email: str = request.form.get('co_authors')
     co_authors_email_list:list = co_authors_email.split('\n') if len(co_authors_email) != 0 else []

--- a/traveller/modules/conf/models.py
+++ b/traveller/modules/conf/models.py
@@ -105,6 +105,10 @@ class Talk(PkModel):
         db.String(20),
         default='pending',
         info={'choices': [('accepted', 'accepted'), ('pending', 'pending'), ('rejected', 'rejected')]})
+    duration = db.Column(
+        db.Integer(),
+        nullable=False,
+        info={'label': 'Duration*'})
 
     submitter_id = db.Column(db.Integer)
     year = db.Column(db.Integer, nullable=False)

--- a/traveller/modules/schedule/forms.py
+++ b/traveller/modules/schedule/forms.py
@@ -28,12 +28,18 @@ class NormalActivityForm(ModelForm):
             },
             'start_time': {
                 'render_kw': {
+                    'min': "09:00",
+                    'max': "18:00",
+                    'step': "1800",
                     'autocomplete': 'off',
                     'required':''
                 }
             },
             'end_time': {
                 'render_kw': {
+                    'min': "09:00",
+                    'max': "18:00",
+                    'step': "1800",
                     'autocomplete': 'off',
                     'required':''
                 }
@@ -49,12 +55,17 @@ class TalkActivityForm(ModelForm):
         field_args = {
             'start_time': {
                 'render_kw': {
+                    'min': "09:00",
+                    'max': "18:00",
+                    'step': "1800",
                     'autocomplete': 'off',
                     'required':''
                 }
             },
             'end_time': {
-                'render_kw': {
+                'render_kw': {'min': "09:00",
+                    'max': "18:00",
+                    'step': "1800",
                     'autocomplete': 'off',
                     'required':''
                 }

--- a/traveller/modules/schedule/forms.py
+++ b/traveller/modules/schedule/forms.py
@@ -6,8 +6,8 @@ from modules.conf.models import Talk
 
 from init import ModelForm
 
-import wtforms_alchemy
-from wtforms_components.fields import TimeField
+from wtforms_alchemy.fields import QuerySelectField
+from wtforms_alchemy import InputRequired
 
 
 class DayForm(ModelForm):
@@ -73,11 +73,15 @@ class TalkActivityForm(ModelForm):
         }
 
 
-    talks = wtforms_alchemy.fields.QuerySelectField(
+    talks = QuerySelectField(
         'Talk:',
-        validators = [wtforms_alchemy.InputRequired()],
+        validators = [InputRequired()],
         query_factory=lambda: Talk.query.filter(
             Talk.year == dt.utcnow().year,
             Talk.accepted == 'accepted'
-            ).all()
+            ).all(),
+        render_kw={
+            'class': "max-w-md"
+        }
     )
+    

--- a/traveller/modules/schedule/models.py
+++ b/traveller/modules/schedule/models.py
@@ -1,7 +1,10 @@
 from datetime import datetime
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
-
-from init import db
+try:
+    from zoneinfo import ZoneInfoNotFoundError
+except ImportError:
+    from backports.zoneinfo import ZoneInfoNotFoundError
+    
+from init import db, conf_time_zone, tzinfo
 from shopyo.api.models import PkModel
 
 
@@ -15,7 +18,7 @@ class Schedule(PkModel):
 class Day(PkModel):
     __tablename__ = "days"
 
-    date = db.Column(db.Date, nullable=False)
+    date = db.Column(db.Date, nullable=False, unique=True, info={"label": "Date:"})
     activities = db.relationship(
         "Activity",
         backref=db.backref("activity_day", lazy=True),
@@ -24,13 +27,22 @@ class Day(PkModel):
 
     schedule_id = db.Column(db.Integer, db.ForeignKey("schedules.id"), nullable=False)
 
-    def get_sorted_activities(self):
-        acts = [[act, act.start_time] for act in self.activities]
-        return sorted(acts, key=lambda l: l[1], reverse=True)
 
-    def get_sorted_activities_based_on_timezone(
-        self, timezoneinfo: str = "Europe/Stockholm"
-    ):
+    def get_sorted_activities_based_on_timezone(self, timezoneinfo: str) -> list:
+        """
+        get_sorted_activities_based_on_timezone Method that sorts the daily activities using the start time.
+
+        The method does the following:
+          - formats both the start and end times of an activity using the timezone information provided:
+          - finds the duration for a normal activity
+          - appends to a list containing activities, their start time, and duration
+          - sorts the list in ascending order using the start time
+
+        :param timezoneinfo: a timezone from the IANA timezone list
+        :type timezoneinfo: str
+        :return: a sorted list containing activities, their start time, and duration
+        :rtype: list
+        """
         acts = []
         for act in self.activities:
             end_datetime = datetime.fromisoformat(f"{self.date} {act.end_time}")
@@ -42,7 +54,7 @@ class Day(PkModel):
                 start_datetime.day,
                 start_datetime.hour,
                 start_datetime.minute,
-                tzinfo=ZoneInfo("Europe/Stockholm"),
+                tzinfo=conf_time_zone,
             )
             end_civil_time = datetime(
                 end_datetime.year,
@@ -50,22 +62,97 @@ class Day(PkModel):
                 end_datetime.day,
                 end_datetime.hour,
                 end_datetime.minute,
-                tzinfo=ZoneInfo("Europe/Stockholm"),
+                tzinfo=conf_time_zone,
             )
 
-            if timezoneinfo != "Europe/Stockholm":
+            if timezoneinfo != "UTC":
                 try:
                     start_civil_time = start_civil_time.astimezone(
-                        tz=ZoneInfo(timezoneinfo)
+                        tz=tzinfo(timezoneinfo)
                     )
-                    end_civil_time = end_civil_time.astimezone(tz=ZoneInfo(timezoneinfo))
+                    end_civil_time = end_civil_time.astimezone(tz=tzinfo(timezoneinfo))
                 except (ValueError, ZoneInfoNotFoundError):
                     pass
 
             activity_time_diff = end_civil_time - start_civil_time
             duration = self.sec_to_time_format(total_secs=activity_time_diff.seconds)
+            if act.type == 'talk':
+                talk = act.get_talk()
+                duration = self.sec_to_time_format(total_secs=talk.duration)
             acts.append([act, start_civil_time, duration])
         return sorted(acts, key=lambda l: l[1], reverse=False)
+
+    def get_time_indicators(self, timezoneinfo: str, year: int):
+        """
+        get_time_indicators Method that provides the time inidicators used for the frontend.
+
+        This method works by first setting the default start date and time of the conference to 1/12/conf_year 09:00:00+UTC.
+        The start date and time is then converted into the timezone information provided.
+        
+        We then generate a list of time indicators in the given timezone.
+        We create a dictionary with the elements in the list of time indicators as key and 
+        a list containing 2 elements as the value.
+
+
+        :param timezoneinfo: a timezone from the IANA timezone list
+        :type timezoneinfo: str
+        :param year: the conference year
+        :type year: int
+        :return: a tuple containing a list of time indicators and a dictionary with time intervals.
+        :rtype: tuple
+        """
+        start_time = datetime(year, 12, 1, 9, 0, tzinfo=conf_time_zone)
+        try:
+            converted_start_time = start_time.astimezone(tz=tzinfo(timezoneinfo))
+        except (ValueError, ZoneInfoNotFoundError):
+            converted_start_time = start_time.astimezone(tz=conf_time_zone)
+
+        indicators = []
+        number_of_hour_intervals = 9    # Initialised as 9 b'cus number of 1 hour intervals between 9:00:00 to 18:00:00 is 9.
+        for item in range(0, number_of_hour_intervals):
+            # The purpose of this loop is to determine the list of time indicators to use when the timezone changes.
+            # For example; if the timezone is set to Australia/Queensland which has a UTC offset of +10:00, then the start time
+            # changes from 9:00:00+UTC to 19:00:00+Australia/Queensland and we could calculate the remaining time indicators.
+            
+            # We loop through a range from 0 to number_of_hour_intervals. We used 9 as the stop for the range 
+            # because the number of 1 hour intervals between 9:00:00 to 18:00:00 is 9.
+
+            cc = converted_start_time
+            c_hour = int(cc.hour + item)
+            if c_hour > 23:
+                # if c_hour > 23 then we subtract 24 it which leaves us with a remainder < 23. 
+                # The remainder represents an hour for the next day
+                c_hour-=24
+            cc = cc.replace(hour=c_hour)
+            indicators.append(cc)
+            cc = cc.replace(minute=30)
+            indicators.append(cc)
+
+        hh = converted_start_time
+        h_hour = int(hh.hour + number_of_hour_intervals)
+        if h_hour > 23:
+                h_hour-=24
+        hh = hh.replace(hour=h_hour)
+        indicators.append(hh)
+
+        pair_indicators = {}
+        prev = indicators[0]
+        for j in range(0, len(indicators)):
+            # The purpose of this loop is to determine the time range that an activity falls under.
+            # We achieve the purpose by creating a dictionary which has a time indicator as the the key and
+            # a list of time indicators (current time indicator and next time indicator) as the value
+            # For example; if time indicator is 9:00:00 then 
+            # the elements in the dictionary will be {"9:00:00": [9:00:00, 9:30:00]}
+
+            try:
+                next_ = indicators[int(j + 1)]
+                pair_indicators.update([(f"{prev}",[prev, next_])])
+                prev = next_
+            except IndexError:
+                next_ = indicators[0]
+                pair_indicators.update(([(f"{prev}",[prev, next_])]))
+                prev = prev
+        return indicators, pair_indicators
 
     def sec_to_time_format(self, total_secs=0):
         # Convert seconds to hours and minutes
@@ -75,7 +162,12 @@ class Day(PkModel):
         total_secs %= 3600
         minutes = (total_secs % 86400) // 60
         total_secs %= 60
-        return f"{hours}h{minutes}min" if hours >= 1 else f"{minutes}min"
+        if hours >= 1 and minutes > 0:
+            duration = f"{hours}h{minutes}m"
+        elif hours >= 1 and minutes <= 0:
+            duration = f"{hours}hr"
+        else: duration = f"{minutes}min"
+        return duration
 
 
 
@@ -93,3 +185,5 @@ class Activity(PkModel):
         from modules.conf.models import Talk
 
         return Talk.query.get(self.talk_id)
+
+    

--- a/traveller/modules/schedule/models.py
+++ b/traveller/modules/schedule/models.py
@@ -45,9 +45,9 @@ class Day(PkModel):
         """
         acts = []
         for act in self.activities:
-            fmt_str =  r"%Y-%m-%dT%H:%M:%S.%f" # replaces the fromisoformat method, not available in Python 3.6
-            end_datetime = datetime.strptime(f"{self.date} {act.end_time}", fmt_str)
-            start_datetime = datetime.strptime(f"{self.date} {act.start_time}", fmt_str)
+            fmt_str =  r"%Y-%m-%dT%H:%M:%S" # replaces the fromisoformat method, not available in Python 3.6
+            end_datetime = datetime.strptime(f"{self.date}T{act.end_time}", fmt_str)
+            start_datetime = datetime.strptime(f"{self.date}T{act.start_time}", fmt_str)
          
 
             start_civil_time = datetime(

--- a/traveller/modules/schedule/models.py
+++ b/traveller/modules/schedule/models.py
@@ -45,8 +45,10 @@ class Day(PkModel):
         """
         acts = []
         for act in self.activities:
-            end_datetime = datetime.fromisoformat(f"{self.date} {act.end_time}")
-            start_datetime = datetime.fromisoformat(f"{self.date} {act.start_time}")
+            fmt_str =  r"%Y-%m-%dT%H:%M:%S.%f" # replaces the fromisoformat method, not available in Python 3.6
+            end_datetime = datetime.strptime(f"{self.date} {act.end_time}", fmt_str)
+            start_datetime = datetime.strptime(f"{self.date} {act.start_time}", fmt_str)
+         
 
             start_civil_time = datetime(
                 start_datetime.year,

--- a/traveller/modules/schedule/models.py
+++ b/traveller/modules/schedule/models.py
@@ -1,41 +1,95 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
 from init import db
 from shopyo.api.models import PkModel
 
 
-
 class Schedule(PkModel):
-    __tablename__ = 'schedules'
-    days = db.relationship('Day',
-        backref=db.backref('day_schedule', lazy=True))
-    
+    __tablename__ = "schedules"
+    days = db.relationship("Day", backref=db.backref("day_schedule", lazy=True))
+
     conf_id = db.Column(db.Integer, db.ForeignKey("conferences.id"), nullable=False)
 
 
 class Day(PkModel):
-    __tablename__ = 'days'
-    
+    __tablename__ = "days"
+
     date = db.Column(db.Date, nullable=False)
-    activities = db.relationship('Activity',
-        backref=db.backref('activity_day', lazy=True), cascade='save-update, delete')
+    activities = db.relationship(
+        "Activity",
+        backref=db.backref("activity_day", lazy=True),
+        cascade="save-update, delete",
+    )
 
     schedule_id = db.Column(db.Integer, db.ForeignKey("schedules.id"), nullable=False)
 
     def get_sorted_activities(self):
         acts = [[act, act.start_time] for act in self.activities]
-        return sorted(acts,key=lambda l:l[1], reverse=True)
+        return sorted(acts, key=lambda l: l[1], reverse=True)
+
+    def get_sorted_activities_based_on_timezone(
+        self, timezoneinfo: str = "Europe/Stockholm"
+    ):
+        acts = []
+        for act in self.activities:
+            end_datetime = datetime.fromisoformat(f"{self.date} {act.end_time}")
+            start_datetime = datetime.fromisoformat(f"{self.date} {act.start_time}")
+
+            start_civil_time = datetime(
+                start_datetime.year,
+                start_datetime.month,
+                start_datetime.day,
+                start_datetime.hour,
+                start_datetime.minute,
+                tzinfo=ZoneInfo("Europe/Stockholm"),
+            )
+            end_civil_time = datetime(
+                end_datetime.year,
+                end_datetime.month,
+                end_datetime.day,
+                end_datetime.hour,
+                end_datetime.minute,
+                tzinfo=ZoneInfo("Europe/Stockholm"),
+            )
+
+            if timezoneinfo != "Europe/Stockholm":
+                try:
+                    start_civil_time = start_civil_time.astimezone(
+                        tz=ZoneInfo(timezoneinfo)
+                    )
+                    end_civil_time = end_civil_time.astimezone(tz=ZoneInfo(timezoneinfo))
+                except (ValueError, ZoneInfoNotFoundError):
+                    pass
+
+            activity_time_diff = end_civil_time - start_civil_time
+            duration = self.sec_to_time_format(total_secs=activity_time_diff.seconds)
+            acts.append([act, start_civil_time, duration])
+        return sorted(acts, key=lambda l: l[1], reverse=False)
+
+    def sec_to_time_format(self, total_secs=0):
+        # Convert seconds to hours and minutes
+        # Separate seconds into hours, and minutes
+        total_secs = total_secs
+        hours = (total_secs % 86400) // 3600
+        total_secs %= 3600
+        minutes = (total_secs % 86400) // 60
+        total_secs %= 60
+        return f"{hours}h{minutes}min" if hours >= 1 else f"{minutes}min"
+
 
 
 class Activity(PkModel):
-    __tablename__ = 'activities'
-    
+    __tablename__ = "activities"
 
     type = db.Column(db.String(300))
-    text = db.Column(db.String(300), info={'label': 'Text:'})
-    start_time = db.Column(db.Time, info={'label': 'Start time:'}, nullable=False)
-    end_time = db.Column(db.Time, info={'label': 'End time:'}, nullable=False)
+    text = db.Column(db.String(300), info={"label": "Text:"})
+    start_time = db.Column(db.Time, info={"label": "Start time:"}, nullable=False)
+    end_time = db.Column(db.Time, info={"label": "End time:"}, nullable=False)
     talk_id = db.Column(db.Integer)
     day_id = db.Column(db.Integer, db.ForeignKey("days.id"), nullable=False)
 
     def get_talk(self):
         from modules.conf.models import Talk
+
         return Talk.query.get(self.talk_id)

--- a/traveller/modules/schedule/view.py
+++ b/traveller/modules/schedule/view.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
-from zoneinfo import ZoneInfo
-from flask import flash
+import re
 
+from init import conf_time_zone
 from shopyo.api.module import ModuleHelp
 from modules.conf.models import Conf
 from modules.schedule.models import Schedule
@@ -11,17 +11,16 @@ from modules.schedule.forms import DayForm
 from modules.schedule.forms import NormalActivityForm
 from modules.schedule.forms import TalkActivityForm
 
-from shopyo.api.html import notify_danger
 from helpers.c2021.notif import alert_success
 from helpers.c2021.notif import alert_danger
 
-
 from flask_login import login_required
 from flask_login import current_user
+from sqlalchemy.exc import IntegrityError
+
 # from flask import render_template
 # from flask import url_for
 # from flask import redirect
-# from flask import flash
 # from flask import request
 
 # from shopyo.api.html import notify_success
@@ -34,131 +33,254 @@ module_blueprint = globals()[mhelp.blueprint_str]
 
 @module_blueprint.route("/")
 def index():
-    return mhelp.info['display_string']
+    return mhelp.info["display_string"]
 
 
 @module_blueprint.route("/<int:year>/day/", methods=["POST"])
 def add_day(year):
     if current_user.is_admin:
-        conf = Conf.query.filter(
-                Conf.year==year
-            ).first()
+        conf = Conf.query.filter(Conf.year == year).first()
 
         if conf.schedule is None:
             conf.schedule = Schedule()
 
         form = DayForm()
         if not form.validate():
-            alert_danger('Day not added!')
-            return mhelp.redirect_url('y.schedule', year=year)
+            alert_danger("Day not added!")
+            return mhelp.redirect_url("y.schedule", year=year)
 
         if form.date.data < date.today():
-            alert_danger("new schedule date should be today or later")
-            return mhelp.redirect_url('y.schedule', year=year)
-        
-        day = Day(
-            date=form.date.data
-            )
+            alert_danger("New schedule date should be today or later")
+            return mhelp.redirect_url("y.schedule", year=year)
+
+        day = Day(date=form.date.data)
+
         conf.schedule.days.append(day)
         conf.update()
-    return mhelp.redirect_url('y.schedule', year=year)
+    return mhelp.redirect_url("y.schedule", year=year)
 
 
 @module_blueprint.route("/<int:year>/day/<day_id>/<act_type>", methods=["POST"])
 def add_activity(year, day_id, act_type):
-    if act_type == 'normal_activity':
+    if act_type == "normal_activity":
         day = Day.query.get(day_id)
-        
+
         if day is None:
-            alert_danger('Invalid day.')
-            return mhelp.redirect_url('y.schedule', year=year)
+            alert_danger("Invalid day.")
+            return mhelp.redirect_url("y.schedule", year=year)
         form = NormalActivityForm()
 
         if not form.validate():
-            alert_danger("Activity not added!") 
-            return mhelp.redirect_url('y.schedule', year=year)
-       
+            alert_danger("Activity not added!")
+            return mhelp.redirect_url("y.schedule", year=year)
+
         if form.end_time.data < form.start_time.data:
             alert_danger("End time should be greater than start date")
-            return mhelp.redirect_url('y.schedule', year=year)
+            return mhelp.redirect_url("y.schedule", year=year)
 
-        # re.search(r"[0-9]{2}:[03]{2}:[0-9]{2}", "01:00:00")
-        # [True for i in ("10:30:00", "12:00:00") if "09:00:00" <= i <= "18:00:00"]
-        starttime_in_iso_format = f"{day.date} {form.start_time.data}"
-        endtime_in_iso_format = f"{day.date} {form.end_time.data}"
-        activity_start = datetime.fromisoformat(starttime_in_iso_format)\
-            .astimezone(tz=ZoneInfo('Europe/Stockholm')).time()
-        activity_end = datetime.fromisoformat(endtime_in_iso_format)\
-            .astimezone(tz=ZoneInfo('Europe/Stockholm')).time()
+        # Check to ensure both start and end time are between 09:00 to 18:00
+        # and ensure the minute hand for a start or end time is either o'clock or 30 minute.
+        # Eg: A valid value for start will be 11:00 or 11:30
+
+        activity_time_check = [
+            True
+            for i in (form.start_time.data, form.end_time.data)
+            if "09:00:00" <= str(i) <= "18:00:00"
+            and re.search(r"[0-9]{2}:(00|30):[0-9]{2}", str(i)) is not None
+        ]
+        if len(activity_time_check) != 2:
+            alert_danger("Provide valid values for both start and end time.")
+            return mhelp.redirect_url("y.schedule", year=year)
+
+        # Convert both the start and end times with the default time zone for the conference
+        activity_start = datetime(
+            int(str(day.date).split("-")[0]),
+            int(str(day.date).split("-")[1]),
+            int(str(day.date).split("-")[2]),
+            int(str(form.start_time.data).split(":")[0]),
+            int(str(form.start_time.data).split(":")[1]),
+            tzinfo=conf_time_zone,
+        )
+        activity_end = datetime(
+            int(str(day.date).split("-")[0]),
+            int(str(day.date).split("-")[1]),
+            int(str(day.date).split("-")[2]),
+            int(str(form.end_time.data).split(":")[0]),
+            int(str(form.end_time.data).split(":")[1]),
+            tzinfo=conf_time_zone,
+        )
 
         activity = Activity()
         form.populate_obj(activity)
-        activity.type = 'normal_activity'
+        activity.type = "normal_activity"
         activity.start_time = activity_start
         activity.end_time = activity_end
         day.activities.append(activity)
         day.update()
-    elif act_type == 'talk':
+    elif act_type == "talk":
         day = Day.query.get(day_id)
         if day is None:
-            alert_danger('Invalid day.')
-            return mhelp.redirect_url('y.schedule', year=year)
+            alert_danger("Invalid day.")
+            return mhelp.redirect_url("y.schedule", year=year)
         form = TalkActivityForm()
-        
+
         if not form.validate():
-            alert_danger("Activity not added!") 
-            return mhelp.redirect_url('y.schedule', year=year)
+            alert_danger("Activity not added!")
+            return mhelp.redirect_url("y.schedule", year=year)
         if form.end_time.data < form.start_time.data:
             alert_danger("End time should be greater than start date")
-            return mhelp.redirect_url('y.schedule', year=year)
+            return mhelp.redirect_url("y.schedule", year=year)
+
+        # Check to ensure both start and end time are between 09:00 to 18:00
+        # and ensure the minute hand for a start or end time is either o'clock or 30 minute.
+        # Eg: A valid value for start will be 11:00 or 11:30
+
+        activity_time_check = [
+            True
+            for i in (form.start_time.data, form.end_time.data)
+            if "09:00:00" <= str(i) <= "18:00:00"
+            and re.search(r"[0-9]{2}:(00|30):[0-9]{2}", str(i)) is not None
+        ]
+        if len(activity_time_check) != 2:
+            alert_danger("Provide valid values for both start and end time.")
+            return mhelp.redirect_url("y.schedule", year=year)
+
+       # Convert both the start and end times with the default time zone for the conference
+        activity_start = datetime(
+            int(str(day.date).split("-")[0]),
+            int(str(day.date).split("-")[1]),
+            int(str(day.date).split("-")[2]),
+            int(str(form.start_time.data).split(":")[0]),
+            int(str(form.start_time.data).split(":")[1]),
+            tzinfo=conf_time_zone,
+        )
+        activity_end = datetime(
+            int(str(day.date).split("-")[0]),
+            int(str(day.date).split("-")[1]),
+            int(str(day.date).split("-")[2]),
+            int(str(form.end_time.data).split(":")[0]),
+            int(str(form.end_time.data).split(":")[1]),
+            tzinfo=conf_time_zone,
+        )
 
         activity = Activity()
         # form.populate_obj(activity)
-        activity.start_time = form.start_time.data
-        activity.end_time = form.end_time.data
-        activity.type = 'talk'
+        activity.start_time = activity_start
+        activity.end_time = activity_end
+        activity.type = "talk"
         activity.talk_id = form.talks.data.id if form.talks.data is not None else None
         day.activities.append(activity)
         day.update()
 
-    return mhelp.redirect_url('y.schedule', year=year)
+    return mhelp.redirect_url("y.schedule", year=year)
 
 
 @module_blueprint.route("/<int:year>/act/<act_id>/edit/<act_type>", methods=["POST"])
 def edit_activity(year, act_id, act_type):
-    if act_type == 'normal_activity':
+    if act_type == "normal_activity":
         form = NormalActivityForm()
         if not form.validate():
             alert_danger("Activity not edited!")
-            return mhelp.redirect_url('y.schedule', year=year)
+            return mhelp.redirect_url("y.schedule", year=year)
         if form.end_time.data < form.start_time.data:
             alert_danger("End time should be greater than start date")
-            return mhelp.redirect_url('y.schedule', year=year)
+            return mhelp.redirect_url("y.schedule", year=year)
+
+        # Check to ensure both start and end time are between 09:00 to 18:00
+        # and ensure the minute hand for a start or end time is either o'clock or 30 minute.
+        # Eg: A valid value for start will be 11:00 or 11:30
+
+        activity_time_check = [
+            True
+            for i in (form.start_time.data, form.end_time.data)
+            if "09:00:00" <= str(i) <= "18:00:00"
+            and re.search(r"[0-9]{2}:(00|30):[0-9]{2}", str(i)) is not None
+        ]
+        if len(activity_time_check) != 2:
+            alert_danger("Provide valid values for both start and end time.")
+            return mhelp.redirect_url("y.schedule", year=year)
+
         activity = Activity.query.get(act_id)
+        day = Day.query.get(activity.day_id)
+
+        # Convert both the start and end times with the default time zone for the conference
+        activity_start = datetime(
+            int(str(day.date).split("-")[0]),
+            int(str(day.date).split("-")[1]),
+            int(str(day.date).split("-")[2]),
+            int(str(form.start_time.data).split(":")[0]),
+            int(str(form.start_time.data).split(":")[1]),
+            tzinfo=conf_time_zone,
+        )
+        activity_end = datetime(
+            int(str(day.date).split("-")[0]),
+            int(str(day.date).split("-")[1]),
+            int(str(day.date).split("-")[2]),
+            int(str(form.end_time.data).split(":")[0]),
+            int(str(form.end_time.data).split(":")[1]),
+            tzinfo=conf_time_zone,
+        )
         if activity is None:
-            alert_danger('Invalid activity.')
-            return mhelp.redirect_url('y.schedule', year=year)
-        form.populate_obj(activity)
+            alert_danger("Invalid activity.")
+            return mhelp.redirect_url("y.schedule", year=year)
+        # form.populate_obj(activity)
+        activity.start_time = activity_start
+        activity.end_time = activity_end
         activity.update()
-    elif act_type == 'talk':
+    elif act_type == "talk":
         form = TalkActivityForm()
         if not form.validate():
             alert_danger("Activity not edited!")
-            return mhelp.redirect_url('y.schedule', year=year)
+            return mhelp.redirect_url("y.schedule", year=year)
 
         if form.end_time.data < form.start_time.data:
             alert_danger("End date should be greater than start date")
-            return mhelp.redirect_url('y.schedule', year=year)
-        activity = Activity.query.get(act_id)
-        if activity is None:
-            alert_danger('Invalid activity.')
-            return mhelp.redirect_url('y.schedule', year=year)
-        activity.start_time = form.start_time.data
-        activity.end_time = form.end_time.data
-        activity.talk_id = form.talks.data.id if form.talks.data is not None else None
+            return mhelp.redirect_url("y.schedule", year=year)
 
+        # Check to ensure both start and end time are between 09:00 to 18:00
+        # and ensure the minute hand for a start or end time is either o'clock or 30 minute.
+        # Eg: A valid value for start will be 11:00 or 11:30
+
+        activity_time_check = [
+            True
+            for i in (form.start_time.data, form.end_time.data)
+            if "09:00:00" <= str(i) <= "18:00:00"
+            and re.search(r"[0-9]{2}:(00|30):[0-9]{2}", str(i)) is not None
+        ]
+        if len(activity_time_check) != 2:
+            alert_danger("Provide valid values for both start and end time.")
+            return mhelp.redirect_url("y.schedule", year=year)
+
+        activity = Activity.query.get(act_id)
+        day = Day.query.get(activity.day_id)
+
+        # Convert both the start and end times with the default time zone for the conference
+        activity_start = datetime(
+            int(str(day.date).split("-")[0]),
+            int(str(day.date).split("-")[1]),
+            int(str(day.date).split("-")[2]),
+            int(str(form.start_time.data).split(":")[0]),
+            int(str(form.start_time.data).split(":")[1]),
+            tzinfo=conf_time_zone,
+        )
+        activity_end = datetime(
+            int(str(day.date).split("-")[0]),
+            int(str(day.date).split("-")[1]),
+            int(str(day.date).split("-")[2]),
+            int(str(form.end_time.data).split(":")[0]),
+            int(str(form.end_time.data).split(":")[1]),
+            tzinfo=conf_time_zone,
+        )
+
+        if activity is None:
+            alert_danger("Invalid activity.")
+            return mhelp.redirect_url("y.schedule", year=year)
+
+        activity.talk_id = form.talks.data.id if form.talks.data is not None else None
+        activity.start_time = activity_start
+        activity.end_time = activity_end
         activity.update()
-    return mhelp.redirect_url('y.schedule', year=year)
+    return mhelp.redirect_url("y.schedule", year=year)
 
 
 @module_blueprint.route("/<int:year>/day/<day_id>/edit", methods=["POST"])
@@ -167,33 +289,37 @@ def edit_day(year, day_id):
         day = Day.query.get(day_id)
 
         if day is None:
-            alert_danger('Invalid day.')
-            return mhelp.redirect_url('y.schedule', year=year)
-        form = DayForm(obj=day)
-        form.populate_obj(day)
-        if not form.validate():
-            alert_danger('Day not edited!')
-            return mhelp.redirect_url('y.schedule', year=year)
+            alert_danger("Invalid day.")
+            return mhelp.redirect_url("y.schedule", year=year)
+        try:
+            form = DayForm(obj=day)
+            form.populate_obj(day)
+            if not form.validate():
+                alert_danger("Day not edited!")
+                return mhelp.redirect_url("y.schedule", year=year)
 
-        if form.date.data < date.today():
-            flash(notify_danger("new schedule date should be today or later"))
-            return mhelp.redirect_url('y.schedule', year=year)
+            if form.date.data < date.today():
+                alert_danger("New schedule date should be today or later")
+                return mhelp.redirect_url("y.schedule", year=year)
 
-        day.update()
-        alert_success('Day edited!')
-    return mhelp.redirect_url('y.schedule', year=year)
+            day.update()
+            alert_success("Day edited!")
+        except IntegrityError:
+            alert_danger("Day not edited!")
+    return mhelp.redirect_url("y.schedule", year=year)
+
 
 @module_blueprint.route("/<int:year>/act/<act_id>/delete", methods=["GET"])
 def delete_activity(year, act_id):
     if not current_user.is_admin:
         alert_danger("You don't have access to delete activity.")
-        return mhelp.redirect_url('y.schedule', year=year)
+        return mhelp.redirect_url("y.schedule", year=year)
     activity = Activity.query.get(act_id)
     if activity is None:
-        alert_danger('Invalid activity.')
-        return mhelp.redirect_url('y.schedule', year=year)
+        alert_danger("Invalid activity.")
+        return mhelp.redirect_url("y.schedule", year=year)
     activity.delete()
-    return mhelp.redirect_url('y.schedule', year=year)
+    return mhelp.redirect_url("y.schedule", year=year)
 
 
 @module_blueprint.route("/<int:year>/day/<day_id>/delete")
@@ -201,12 +327,12 @@ def delete_activity(year, act_id):
 def delete_day(year, day_id):
     if not current_user.is_admin:
         alert_danger("You don't have access to delete days!")
-        return mhelp.redirect_url('y.schedule', year=year)
+        return mhelp.redirect_url("y.schedule", year=year)
 
     day = Day.query.get(day_id)
     if day is None:
-        alert_danger('Invalid day.')
-        return mhelp.redirect_url('y.schedule', year=year)
+        alert_danger("Invalid day.")
+        return mhelp.redirect_url("y.schedule", year=year)
     day.delete()
-    alert_success('Day deleted!')
-    return mhelp.redirect_url('y.schedule', year=year)
+    alert_success("Day deleted!")
+    return mhelp.redirect_url("y.schedule", year=year)

--- a/traveller/modules/y/tests/test_y_functional.py
+++ b/traveller/modules/y/tests/test_y_functional.py
@@ -4,6 +4,7 @@ from modules.conf.models import Conf, ReviewerList, AuthorList
 from modules.conf.models import Talk
 from modules.schedule.models import Schedule, Day, Activity
 
+from app import app
 
 
 def create_conf(now, current_year):
@@ -66,6 +67,7 @@ def test_view_profile_page(test_client, login_non_admin_user, current_year, non_
         year=conf.year,
         conf_id=conf.id,
         submitter_id=non_admin_user.id,
+        duration=1800
     )
     talk.create_slug()
     talk.author_list = AuthorList()
@@ -80,6 +82,7 @@ def test_view_profile_page(test_client, login_non_admin_user, current_year, non_
         year=last_year.year,
         conf_id=last_conf.id,
         submitter_id=non_admin_user.id,
+        duration=1800
     )
     old_talk.create_slug()
     old_talk.author_list = AuthorList()
@@ -108,6 +111,7 @@ def test_view_review_page(test_client, login_non_admin_user, current_year, non_a
         year=conf.year,
         conf_id=conf.id,
         submitter_id=non_admin_user.id,
+        duration=1800
     )
     talk.create_slug()
     talk.author_list = AuthorList()
@@ -134,6 +138,7 @@ def test_view_leaderboard_page(test_client, login_non_admin_user, current_year, 
         year=conf.year,
         conf_id=conf.id,
         submitter_id=non_admin_user.id,
+        duration=1800
     )
     talk.create_slug()
     talk.author_list = AuthorList()
@@ -145,6 +150,7 @@ def test_view_leaderboard_page(test_client, login_non_admin_user, current_year, 
 
 
 def test_view_schedule_page(test_client, login_non_admin_user, current_year):
+    
     now = datetime.datetime.now()
     conf = create_conf(now, current_year)
     Schedule.create(

--- a/traveller/modules/y/view.py
+++ b/traveller/modules/y/view.py
@@ -15,8 +15,8 @@ from modules.profile.forms import UserProfileForm
 # from flask import url_for
 # from flask import redirect
 # from flask import flash
-# from flask import request
 
+from flask import request
 from flask_login import current_user
 from flask_login import login_required
 
@@ -149,6 +149,7 @@ def leaderboard(year):
 @module_blueprint.route("/<int:year>/schedule/")
 def schedule(year):
     context = mhelp.context()
+    timezone = request.args.get("tz", "UTC")
     DayForm_ = DayForm
     conf = Conf.query.filter(
         Conf.year == year
@@ -169,6 +170,10 @@ def schedule(year):
     schedule = conf.schedule
     NormalActivityForm_ = NormalActivityForm
     TalkActivityForm_ = TalkActivityForm
+
+    if not current_user.is_admin:
+        context.update(locals())
+        return render_template('conftheme/{}/parts/schedule_2.html'.format(year), **context)
     context.update(locals())
     return render_template('conftheme/{}/parts/schedule.html'.format(year), **context)
 

--- a/traveller/seed.py
+++ b/traveller/seed.py
@@ -71,6 +71,7 @@ def add_conf():
         talk.description = t[2]
         talk.notes = t[3]
         talk.level = 'beginner'
+        talk.duration = 1800
         talk.submitter_id = 1
         talk.author_list = AuthorList()
         talk.author_list.authors.append(admin)

--- a/traveller/static/js/custom.js
+++ b/traveller/static/js/custom.js
@@ -1,0 +1,41 @@
+// Time zone effect handlers
+let tz_select = document.getElementById("select-timezone");
+let user_timezone_opt = document.getElementById("user-timezone");
+let get_user_timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+user_timezone_opt.value = get_user_timezone;
+user_timezone_opt.innerHTML = get_user_timezone;
+
+tz_select.addEventListener("change", function(){
+    url_addr = window.location.origin + window.location.pathname + `?tz=${this.value}`;
+    window.location.replace(`${url_addr}`);
+})
+// Time zone effect handlers
+
+// Upward scroll effect handlers
+const btn_upward = document.getElementById("up_button");
+const rootElement = document.documentElement;
+
+btn_upward.addEventListener("click", function(){
+    rootElement.scrollTo({
+    top: 300,
+    behavior: "smooth"
+  })
+})
+
+function handleScroll() {
+  // Do something on scroll
+  let scrollTotal = rootElement.scrollHeight - rootElement.clientHeight
+  if ((rootElement.scrollTop / scrollTotal ) > 0.15 ) {
+    // Show button
+    btn_upward.classList.add("block");
+    btn_upward.classList.remove("hidden")
+  } else {
+    // Hide button
+    btn_upward.classList.remove("block");
+    btn_upward.classList.add("hidden")
+  }
+}
+
+document.addEventListener("scroll", handleScroll)
+// Upward scroll effect handlers

--- a/traveller/static/themes/front/conftheme/2021/parts/cfp.html
+++ b/traveller/static/themes/front/conftheme/2021/parts/cfp.html
@@ -20,7 +20,9 @@ textarea {
 #notes {
     height: 200px;
 }
+@media (max-width: 640px) {.interval{display: none;}}
 </style>
+
 <title>Submit | FlaskCon</title>
 {% endblock %}
 {% block body %}
@@ -37,16 +39,20 @@ textarea {
                 <form method="POST" action="{{ url_for('cfp.add_talk', year=conf.year) }}">
                     
                     {%for field in talk_form%}
-                    {%if field.id not in ['csrf_token']%}
-                    {{field.label}}
-                    {%endif%}<br>
-                    {{field}}<br><br>
+                        {%if field.id not in ['csrf_token']%}
+                            {{field.label}}<br>
+                        {%endif%}
+                        {{field}}<br>
                     {%endfor%}
-                    
-                    <br>
+                    <label for="duration">Duration*</label><br>
+                    <div class="mb-4" >
+                        <input class="rounded mb-2" autocomplete="off" id="duration" max="18:00" min="09:00" name="start_time" required="" type="time" value="09:00"> <span class="interval">to</span>
+                        <input class="rounded mb-2" autocomplete="off" id="duration" max="18:00" min="09:00" name="end_time" required="" type="time" value="18:00">
+                    </div>
+
                     <label for="co_authors">Co-Authors</label><br>
                     <textarea name="co_authors" id="co_authors" cols="80" rows="5"
-                    class="border-1 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring ease-linear transition-all duration-150"
+                    class="border-1 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded mb-4 text-sm shadow focus:outline-none focus:ring ease-linear transition-all duration-150"
                     placeholder="Enter email address of each co-author on a newline"></textarea>
                     <br>
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/traveller/static/themes/front/conftheme/2021/parts/profile.html
+++ b/traveller/static/themes/front/conftheme/2021/parts/profile.html
@@ -41,17 +41,17 @@ textarea {
                     <div class="w-full">
                         <ul class="flex mb-0 list-none flex-wrap pt-3 pb-4 flex-row">
                             <li class="-mb-px mr-2 last:mr-0 flex-auto text-center">
-                                <a class="text-xs font-bold uppercase px-5 py-3 shadow-lg rounded block leading-normal text-white bg-red-600" data-tab-toggle="text-tab-profile-red" onclick="changeAtiveTab(event,'wrapper-for-text-red','red','text-tab-profile-red')">
+                                <a class="text-xs font-bold uppercase px-5 py-3 shadow-lg rounded block leading-normal text-white bg-red-600" data-tab-toggle="text-tab-profile-red" onclick="changeActiveTab(event,'wrapper-for-text-red','red','text-tab-profile-red')">
                                     Talks
                                 </a>
                             </li>
                             <li class="-mb-px mr-2 last:mr-0 flex-auto text-center">
-                                <a class="text-xs font-bold uppercase px-5 py-3 shadow-lg rounded block leading-normal text-red-600 bg-white" data-tab-toggle="text-tab-settings-red" onclick="changeAtiveTab(event,'wrapper-for-text-red','red','text-tab-settings-red')">
+                                <a class="text-xs font-bold uppercase px-5 py-3 shadow-lg rounded block leading-normal text-red-600 bg-white" data-tab-toggle="text-tab-settings-red" onclick="changeActiveTab(event,'wrapper-for-text-red','red','text-tab-settings-red')">
                                     Profile
                                 </a>
                             </li>
                             <li class="-mb-px mr-2 last:mr-0 flex-auto text-center">
-                                <a class="text-xs font-bold uppercase px-5 py-3 shadow-lg rounded block leading-normal text-red-600 bg-white" data-tab-toggle="text-tab-options-red" onclick="changeAtiveTab(event,'wrapper-for-text-red','red','text-tab-options-red')">
+                                <a class="text-xs font-bold uppercase px-5 py-3 shadow-lg rounded block leading-normal text-red-600 bg-white" data-tab-toggle="text-tab-options-red" onclick="changeActiveTab(event,'wrapper-for-text-red','red','text-tab-options-red')">
                                     Options
                                 </a>
                             </li>
@@ -169,7 +169,7 @@ textarea {
     </div>
 </section>
 <script type="text/javascript">
-function changeAtiveTab(event, wrapperID, color, tabID) {
+function changeActiveTab(event, wrapperID, color, tabID) {
     let tabsWrapper = document.getElementById(wrapperID);
     let tabsAnchors = tabsWrapper.querySelectorAll("[data-tab-toggle]");
     let tabsContent = tabsWrapper.querySelectorAll("[data-tab-content]");

--- a/traveller/static/themes/front/conftheme/2021/parts/schedule.html
+++ b/traveller/static/themes/front/conftheme/2021/parts/schedule.html
@@ -152,11 +152,12 @@ a {
                                         <p class="my-4 text-blueGray-500 text-lg leading-relaxed">
                                             <form method="POST" action="{{ url_for('schedule.add_activity', year=year, day_id=day.id, act_type='talk') }}">
                                                 {%for field in TalkActivityForm_()%}
-                                                {%if field.id not in ['csrf_token']%}
-                                                {{field.label}}<br>
-                                                {%endif%}
-                                                {{field}}<br><br>
+                                                    {%if field.id not in ['csrf_token']%}
+                                                        {{field.label}}<br>
+                                                    {%endif%}
+                                                    {{field}}<br><br>
                                                 {%endfor%}
+
                                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                                 <button class="bg-emerald-500 text-white font-bold text-sm px-4 py-2 rounded shadow hover:shadow-md outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="submit">
                                                     Save
@@ -218,12 +219,11 @@ a {
                         <div class="hidden opacity-25 fixed inset-0 z-40 bg-black" id="edit-day-modal-id-{{ day.id }}-backdrop"></div>
                     {% endif %}
                     <div>
-
-                        {% set activities = day.get_sorted_activities_based_on_timezone("Africa/Accra") %}
+                        {% set activities = day.get_sorted_activities_based_on_timezone(timezone) %}
                         {% for activity_ in activities %}
                         {% set activity = activity_[0] %}
                         {% if activity.type == 'normal_activity' %}
-                            &nbsp;{{ activity_[1].strftime("%I:%M") }} {{ activity_[1].strftime("%p") }} {{ activity_[2] }} ---> {{ activity.text }}
+                            &nbsp;<span class="lowercase">{{ activity_[1].strftime("%I:%M %p") }}</span> {{ activity_[2] }} ---> {{ activity.text }}
                             {% if current_user %}
                             {% if current_user.is_authenticated %}
                             {% if current_user.is_admin %}
@@ -285,7 +285,7 @@ a {
                         <!-- edit talk activity modal -->
                         {% if activity.type == 'talk' %}
                         {% set talk = activity.get_talk() %}
-                            &nbsp;{{ activity.start_time }} to {{ activity.end_time }} ---> {{ talk.title }} by
+                            &nbsp;<span class="lowercase">{{ activity_[1].strftime("%I:%M %p") }}</span> {{ activity_[2] }} ---> {{ talk.title|truncate(50, true) }} by
                         {% if talk is not none %}
                             {% for author in talk.author_list.authors %}
                                 {{author.first_name}} {{author.last_name}}

--- a/traveller/static/themes/front/conftheme/2021/parts/schedule.html
+++ b/traveller/static/themes/front/conftheme/2021/parts/schedule.html
@@ -10,12 +10,40 @@ a {
     height: 500px;
     overflow-y: scroll;
 }
+#day-tab-selector{
+    flex-direction: row;
+  }
 
 @media (max-width: 640px) {
   .day_tools {
     display: block;
     margin-top: 5px;
   }
+  #day-tab-selector{
+    flex-direction: column;
+  }
+  
+}
+@media (max-width: 1280px) {
+    .activity a{
+        max-width: 100%;
+    }
+}
+.activity a.beginner:hover{
+    border: 1px solid #8b0000b0;
+    border-radius: 0.25rem;
+}
+.activity a.intermediate:hover{
+    border: 1px solid #008b17b0;
+    border-radius: 0.25rem;
+}
+.activity a.advance:hover{
+    border: 1px solid #00098bb0;
+    border-radius: 0.25rem;
+}
+.activity a.normal:hover{
+    border: 1px solid #020202b0;
+    border-radius: 0.25rem;
 }
 
 
@@ -36,10 +64,9 @@ a {
             <div class="container bg-white rounded-xl shadow-lg transform transition duration-500 p-7" style="min-height: 800px;">
 
                 <h3 class="text-5xl">Schedule</h3><br>
-                <p>
-                    CFP Start: <span class="p-1 bg-yellow-200">{{ conf.cfp_start_repr() }}</span> 0:00 AM GMT<br>
-                            CFP End: <span class="p-1 bg-yellow-200">{{ conf.cfp_end_repr() }}</span> 0:00 AM GMT
-                </p><br>
+                <p>CFP Start: <span class="p-1 bg-yellow-200">{{ conf.cfp_start_repr() }}</span> 0:00 AM GMT</p>
+                <p>CFP End: <span class="p-1 bg-yellow-200">{{ conf.cfp_end_repr() }}</span> 0:00 AM GMT</p>
+                <br>
                 {% if current_user.is_admin %}
                     <button class="bg-pink-500 text-white active:bg-pink-600 font-bold uppercase text-sm px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onclick="toggleModal('add-day-modal')">
                         + Day
@@ -150,52 +177,53 @@ a {
                         <!-- end talk add -->
                         {% endif %}
                     </div>
-                    <div class="hidden overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none justify-center items-center" id="edit-day-modal-id-{{ day.id }}">
-                        <div class="relative w-auto my-6 mx-auto max-w-3xl">
-                            <!--content-->
-                            <div class="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none">
-                                <!--header-->
-                                <div class="flex items-start justify-between p-5 border-b border-solid border-blueGray-200 rounded-t">
-                                    <h3 class="text-3xl font-semibold">
-                                        Edit Day
-                                    </h3>
-                                    
-                                </div>
-                                <!--body-->
-                                <div class="relative p-6 flex-auto">
-                                    <p class="my-4 text-blueGray-500 text-lg leading-relaxed">
-                                        <form method="POST" action="{{ url_for('schedule.edit_day', day_id=day.id, year=year) }}">
-                                            {%for field in DayForm_(obj=day)%}
-                                            {%if field.id not in ['csrf_token']%}
-                                            {{field.label}}
-                                            {%endif%}
-                                            {{field}}<br>
-                                            {%endfor%}
-                                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                            <button class="bg-emerald-500 text-white font-bold text-sm px-4 py-2 rounded shadow hover:shadow-md outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="submit">
-                                                Save
-                                            </button>
-                                        </form>
-                                    </p>
-                                </div>
-                                <!--footer-->
-                                <div class="flex items-center justify-end p-6 border-t border-solid border-blueGray-200 rounded-b">
-                                    <button class="text-red-500 background-transparent font-bold uppercase px-6 py-2 text-sm outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onclick="toggleModal('edit-day-modal-id-{{ day.id }}')">
-                                        Close
-                                    </button>
+                    {% if current_user.is_admin %}
+                        <div class="hidden overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none justify-center items-center" id="edit-day-modal-id-{{ day.id }}">
+                            <div class="relative w-auto my-6 mx-auto max-w-3xl">
+                                <!--content-->
+                                <div class="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none">
+                                    <!--header-->
+                                    <div class="flex items-start justify-between p-5 border-b border-solid border-blueGray-200 rounded-t">
+                                        <h3 class="text-3xl font-semibold">
+                                            Edit Day
+                                        </h3>
+                                        
+                                    </div>
+                                    <!--body-->
+                                    <div class="relative p-6 flex-auto">
+                                        <p class="my-4 text-blueGray-500 text-lg leading-relaxed">
+                                            <form method="POST" action="{{ url_for('schedule.edit_day', day_id=day.id, year=year) }}">
+                                                {%for field in DayForm_(obj=day)%}
+                                                {%if field.id not in ['csrf_token']%}
+                                                {{field.label}}
+                                                {%endif%}
+                                                {{field}}<br>
+                                                {%endfor%}
+                                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                                <button class="bg-emerald-500 text-white font-bold text-sm px-4 py-2 rounded shadow hover:shadow-md outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="submit">
+                                                    Save
+                                                </button>
+                                            </form>
+                                        </p>
+                                    </div>
+                                    <!--footer-->
+                                    <div class="flex items-center justify-end p-6 border-t border-solid border-blueGray-200 rounded-b">
+                                        <button class="text-red-500 background-transparent font-bold uppercase px-6 py-2 text-sm outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onclick="toggleModal('edit-day-modal-id-{{ day.id }}')">
+                                            Close
+                                        </button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="hidden opacity-25 fixed inset-0 z-40 bg-black" id="edit-day-modal-id-{{ day.id }}-backdrop"></div>
-
+                        <div class="hidden opacity-25 fixed inset-0 z-40 bg-black" id="edit-day-modal-id-{{ day.id }}-backdrop"></div>
+                    {% endif %}
                     <div>
 
-                        {% set activities = day.get_sorted_activities() %}
+                        {% set activities = day.get_sorted_activities_based_on_timezone("Africa/Accra") %}
                         {% for activity_ in activities %}
                         {% set activity = activity_[0] %}
                         {% if activity.type == 'normal_activity' %}
-                            &nbsp;{{ activity.start_time }} to {{ activity.end_time }} ---> {{ activity.text }}
+                            &nbsp;{{ activity_[1].strftime("%I:%M") }} {{ activity_[1].strftime("%p") }} {{ activity_[2] }} ---> {{ activity.text }}
                             {% if current_user %}
                             {% if current_user.is_authenticated %}
                             {% if current_user.is_admin %}
@@ -210,46 +238,48 @@ a {
                             
                             {% endif %}{% endif %}{% endif %}
                             <br>
-                        <!--edit normal activity modal-->
-                        <div class="hidden overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none justify-center items-center" id="edit-normal-activity-modal-id-{{ activity.id }}">
-                            <div class="relative w-auto my-6 mx-auto max-w-3xl">
-                                <!--content-->
-                                <div class="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none">
-                                    <!--header-->
-                                    <div class="flex items-start justify-between p-5 border-b border-solid border-blueGray-200 rounded-t">
-                                        <h3 class="text-3xl font-semibold">
-                                            Edit activity
-                                        </h3>
-                                    </div>
-                                    <!--body-->
-                                    <div class="relative p-6 flex-auto">
-                                        <p class="my-4 text-blueGray-500 text-lg leading-relaxed">
-                                            <form method="POST" action="{{ url_for('schedule.edit_activity', year=year,
-                    act_id=activity.id, act_type='normal_activity') }}">
-                                                {%for field in NormalActivityForm_(obj=activity)%}
-                                                {%if field.id not in ['csrf_token']%}
-                                                {{field.label}}<br>
-                                                {%endif%}
-                                                {{field}}<br><br>
-                                                {%endfor%}
-                                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                                <button class="bg-emerald-500 text-white font-bold text-sm px-4 py-2 rounded shadow hover:shadow-md outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="submit">
-                                                    Save
+                            {% if current_user.is_admin %}
+                                <!--edit normal activity modal-->
+                                <div class="hidden overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none justify-center items-center" id="edit-normal-activity-modal-id-{{ activity.id }}">
+                                    <div class="relative w-auto my-6 mx-auto max-w-3xl">
+                                        <!--content-->
+                                        <div class="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none">
+                                            <!--header-->
+                                            <div class="flex items-start justify-between p-5 border-b border-solid border-blueGray-200 rounded-t">
+                                                <h3 class="text-3xl font-semibold">
+                                                    Edit activity
+                                                </h3>
+                                            </div>
+                                            <!--body-->
+                                            <div class="relative p-6 flex-auto">
+                                                <p class="my-4 text-blueGray-500 text-lg leading-relaxed">
+                                                    <form method="POST" action="{{ url_for('schedule.edit_activity', year=year,
+                            act_id=activity.id, act_type='normal_activity') }}">
+                                                        {%for field in NormalActivityForm_(obj=activity)%}
+                                                        {%if field.id not in ['csrf_token']%}
+                                                        {{field.label}}<br>
+                                                        {%endif%}
+                                                        {{field}}<br><br>
+                                                        {%endfor%}
+                                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                                        <button class="bg-emerald-500 text-white font-bold text-sm px-4 py-2 rounded shadow hover:shadow-md outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="submit">
+                                                            Save
+                                                        </button>
+                                                    </form>
+                                                </p>
+                                            </div>
+                                            <!--footer-->
+                                            <div class="flex items-center justify-end p-6 border-t border-solid border-blueGray-200 rounded-b">
+                                                <button class="text-red-500 background-transparent font-bold uppercase px-6 py-2 text-sm outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onclick="toggleModal('edit-normal-activity-modal-id-{{ activity.id }}')">
+                                                    Close
                                                 </button>
-                                            </form>
-                                        </p>
-                                    </div>
-                                    <!--footer-->
-                                    <div class="flex items-center justify-end p-6 border-t border-solid border-blueGray-200 rounded-b">
-                                        <button class="text-red-500 background-transparent font-bold uppercase px-6 py-2 text-sm outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onclick="toggleModal('edit-normal-activity-modal-id-{{ activity.id }}')">
-                                            Close
-                                        </button>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                        </div>
-                        <div class="hidden opacity-25 fixed inset-0 z-40 bg-black" id="edit-normal-activity-modal-id-{{ activity.id }}-backdrop"></div>
-                        <!-- end edit normal activity modal -->
+                                <div class="hidden opacity-25 fixed inset-0 z-40 bg-black" id="edit-normal-activity-modal-id-{{ activity.id }}-backdrop"></div>
+                                <!-- end edit normal activity modal -->
+                            {% endif %}
                         {% endif %}
                         
                         <!-- edit talk activity modal -->
@@ -261,6 +291,7 @@ a {
                                 {{author.first_name}} {{author.last_name}}
                             {% endfor %}
                         {% endif %}
+
                         {% if current_user %}
                         {% if current_user.is_authenticated %}
                         {% if current_user.is_admin %}
@@ -276,47 +307,48 @@ a {
                         
                         {% endif %}{% endif %}{% endif %}
                         <br>
-                        
-                        <div class="hidden overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none justify-center items-center" id="edit-talk-activity-modal-id-{{ activity.id }}">
-                            <div class="relative w-auto my-6 mx-auto max-w-3xl">
-                                <!--content-->
-                                <div class="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none">
-                                    <!--header-->
-                                    <div class="flex items-start justify-between p-5 border-b border-solid border-blueGray-200 rounded-t">
-                                        <h3 class="text-3xl font-semibold">
-                                            Edit talk activity
-                                        </h3>
-                                    
-                                    </div>
-                                    <!--body-->
-                                    <div class="relative p-6 flex-auto">
-                                        <p class="my-4 text-blueGray-500 text-lg leading-relaxed">
-                                            <form method="POST" action="{{ url_for('schedule.edit_activity', year=year,
-                    act_id=activity.id, act_type='talk') }}">
-                                                {%for field in TalkActivityForm_(obj=activity)%}
-                                                {%if field.id not in ['csrf_token']%}
-                                                {{field.label}}<br>
-                                                {%endif%}
-                                                {{field}}<br><br>
-                                                {%endfor%}
-                                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                                <button class="bg-emerald-500 text-white font-bold text-sm px-4 py-2 rounded shadow hover:shadow-md outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="submit">
-                                                    Save
+                            {% if current_user.is_admin %}
+                                <div class="hidden overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none justify-center items-center" id="edit-talk-activity-modal-id-{{ activity.id }}">
+                                    <div class="relative w-auto my-6 mx-auto max-w-3xl">
+                                        <!--content-->
+                                        <div class="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none">
+                                            <!--header-->
+                                            <div class="flex items-start justify-between p-5 border-b border-solid border-blueGray-200 rounded-t">
+                                                <h3 class="text-3xl font-semibold">
+                                                    Edit talk activity
+                                                </h3>
+                                            
+                                            </div>
+                                            <!--body-->
+                                            <div class="relative p-6 flex-auto">
+                                                <p class="my-4 text-blueGray-500 text-lg leading-relaxed">
+                                                    <form method="POST" action="{{ url_for('schedule.edit_activity', year=year,
+                            act_id=activity.id, act_type='talk') }}">
+                                                        {%for field in TalkActivityForm_(obj=activity)%}
+                                                        {%if field.id not in ['csrf_token']%}
+                                                        {{field.label}}<br>
+                                                        {%endif%}
+                                                        {{field}}<br><br>
+                                                        {%endfor%}
+                                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                                        <button class="bg-emerald-500 text-white font-bold text-sm px-4 py-2 rounded shadow hover:shadow-md outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="submit">
+                                                            Save
+                                                        </button>
+                                                    </form>
+                                                </p>
+                                            </div>
+                                            <!--footer-->
+                                            <div class="flex items-center justify-end p-6 border-t border-solid border-blueGray-200 rounded-b">
+                                                <button class="text-red-500 background-transparent font-bold uppercase px-6 py-2 text-sm outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onclick="toggleModal('edit-talk-activity-modal-id-{{ activity.id }}')">
+                                                    Close
                                                 </button>
-                                            </form>
-                                        </p>
-                                    </div>
-                                    <!--footer-->
-                                    <div class="flex items-center justify-end p-6 border-t border-solid border-blueGray-200 rounded-b">
-                                        <button class="text-red-500 background-transparent font-bold uppercase px-6 py-2 text-sm outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onclick="toggleModal('edit-talk-activity-modal-id-{{ activity.id }}')">
-                                            Close
-                                        </button>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                        </div>
-                        <div class="hidden opacity-25 fixed inset-0 z-40 bg-black" id="edit-talk-activity-modal-id-{{ activity.id }}-backdrop"></div>
-                        <!-- end edit talk activity modal -->
+                                <div class="hidden opacity-25 fixed inset-0 z-40 bg-black" id="edit-talk-activity-modal-id-{{ activity.id }}-backdrop"></div>
+                                <!-- end edit talk activity modal -->                              
+                            {% endif %}
                         {% endif %}
                         {% endfor %}
                     </div>
@@ -325,55 +357,57 @@ a {
         </div>
     </div>
 </section>
-{% if current_user.is_admin %}
-{% include 'base/blocks/flashed_messages.html'%}
-<div class="hidden overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none justify-center items-center" id="add-day-modal">
-    <div class="relative w-auto my-6 mx-auto max-w-3xl">
-        <!--content-->
-        <div class="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none">
-            <!--header-->
-            <div class="flex items-start justify-between p-5 border-b border-solid border-blueGray-200 rounded-t">
-                <h3 class="text-3xl font-semibold">
-                    Add Day
-                </h3>
-                
-            </div>
-            <!--body-->
-            <div class="relative p-6 flex-auto">
-                <p class="my-4 text-blueGray-500 text-lg leading-relaxed">
-                    <form method="POST" action="{{ url_for('schedule.add_day', year=year) }}">
-                        {%for field in DayForm_()%}
-                        {%if field.id not in ['csrf_token']%}
-                        {{field.label}}
-                        {%endif%}
-                        {{field}}<br>
-                        {%endfor%}
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <button class="bg-emerald-500 text-white font-bold text-sm px-4 py-2 rounded shadow hover:shadow-md outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="submit">
-                            Save
+    {% if current_user.is_admin %}
+        {% include 'base/blocks/flashed_messages.html'%}
+        <div class="hidden overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none justify-center items-center" id="add-day-modal">
+            <div class="relative w-auto my-6 mx-auto max-w-3xl">
+                <!--content-->
+                <div class="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none">
+                    <!--header-->
+                    <div class="flex items-start justify-between p-5 border-b border-solid border-blueGray-200 rounded-t">
+                        <h3 class="text-3xl font-semibold">
+                            Add Day
+                        </h3>
+                        
+                    </div>
+                    <!--body-->
+                    <div class="relative p-6 flex-auto">
+                        <p class="my-4 text-blueGray-500 text-lg leading-relaxed">
+                            <form method="POST" action="{{ url_for('schedule.add_day', year=year) }}">
+                                {%for field in DayForm_()%}
+                                {%if field.id not in ['csrf_token']%}
+                                {{field.label}}
+                                {%endif%}
+                                {{field}}<br>
+                                {%endfor%}
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button class="bg-emerald-500 text-white font-bold text-sm px-4 py-2 rounded shadow hover:shadow-md outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="submit">
+                                    Save
+                                </button>
+                            </form>
+                        </p>
+                    </div>
+                    <!--footer-->
+                    <div class="flex items-center justify-end p-6 border-t border-solid border-blueGray-200 rounded-b">
+                        <button class="text-red-500 background-transparent font-bold uppercase px-6 py-2 text-sm outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onclick="toggleModal('add-day-modal')">
+                            Close
                         </button>
-                    </form>
-                </p>
-            </div>
-            <!--footer-->
-            <div class="flex items-center justify-end p-6 border-t border-solid border-blueGray-200 rounded-b">
-                <button class="text-red-500 background-transparent font-bold uppercase px-6 py-2 text-sm outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onclick="toggleModal('add-day-modal')">
-                    Close
-                </button>
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
-</div>
-<div class="hidden opacity-25 fixed inset-0 z-40 bg-black" id="add-day-modal-backdrop"></div>
+        <div class="hidden opacity-25 fixed inset-0 z-40 bg-black" id="add-day-modal-backdrop"></div>
 
 
-<script type="text/javascript">
-function toggleModal(modalID) {
-    document.getElementById(modalID).classList.toggle("hidden");
-    document.getElementById(modalID + "-backdrop").classList.toggle("hidden");
-    document.getElementById(modalID).classList.toggle("flex");
-    document.getElementById(modalID + "-backdrop").classList.toggle("flex");
-}
-</script>
-{% endif %}
+        <script type="text/javascript">
+        function toggleModal(modalID) {
+            document.getElementById(modalID).classList.toggle("hidden");
+            document.getElementById(modalID + "-backdrop").classList.toggle("hidden");
+            document.getElementById(modalID).classList.toggle("flex");
+            document.getElementById(modalID + "-backdrop").classList.toggle("flex");
+        }
+        </script>
+    {% endif %}
+
+
 {% endblock %}

--- a/traveller/static/themes/front/conftheme/2021/parts/schedule_2.html
+++ b/traveller/static/themes/front/conftheme/2021/parts/schedule_2.html
@@ -1,263 +1,422 @@
-{% extends 'conftheme/2021/parts/base.html'%}
+{% extends 'conftheme/2021/parts/base.html' %}
 {% block head %}
-<title>Schedule | FlaskCon</title>
-<style type="text/css">
-a {
-    word-wrap: break-word;
-}
+    <title>Schedule | FlaskCon</title>
+    <style type="text/css">
+        a {
+            word-wrap: break-word;
+        }
 
-.modal-body {
-    height: 500px;
-    overflow-y: scroll;
-}
-#day-tab-selector{
-    flex-direction: row;
-  }
+        .modal-body {
+            height: 500px;
+            overflow-y: scroll;
+        }
+        #day-tab-selector {
+            flex-direction: row;
+        }
 
-@media (max-width: 640px) {
-  .day_tools {
-    display: block;
-    margin-top: 5px;
-  }
-  #day-tab-selector{
-    flex-direction: column;
-  }
-  
-}
-@media (max-width: 1280px) {
-    .activity a{
-        max-width: 100%;
-    }
-}
-.activity a.beginner:hover{
-    border: 1px solid #8b0000b0;
-    border-radius: 0.25rem;
-}
-.activity a.intermediate:hover{
-    border: 1px solid #008b17b0;
-    border-radius: 0.25rem;
-}
-.activity a.advance:hover{
-    border: 1px solid #00098bb0;
-    border-radius: 0.25rem;
-}
-.activity a.normal:hover{
-    border: 1px solid #020202b0;
-    border-radius: 0.25rem;
-}
+        @media(max-width: 640px) {
+            .day_tools {
+                display: block;
+                margin-top: 5px;
+            }
+            #day-tab-selector {
+                flex-direction: column;
+            }
+
+        }
+        @media(max-width: 1280px) {
+            .activity a {
+                max-width: 100%;
+            }
+        }
+        .activity a.beginner:hover {
+            border: 1px solid #8b0000b0;
+            border-radius: 0.25rem;
+        }
+        .activity a.intermediate:hover {
+            border: 1px solid #008b17b0;
+            border-radius: 0.25rem;
+        }
+        .activity a.advance:hover {
+            border: 1px solid #00098bb0;
+            border-radius: 0.25rem;
+        }
+        .activity a.normal:hover {
+            border: 1px solid #020202b0;
+            border-radius: 0.25rem;
+        }
 
 
-@media (max-width: 380px) {
-  .activity_tools {
-    display: block;
-    margin-top: 3px;
-  }
-}
-</style>
+        @media(max-width: 380px) {
+            .activity_tools {
+                display: block;
+                margin-top: 3px;
+            }
+        }
+    </style>
 {% endblock %}
 {% block body %}
-<p class="pb-16 bg-red-500"></p>
-<section class="pb-20 bg-blueGray-200">
-    <p class="p-5 bg-transparent"></p>
-    <div class="container mx-auto px-4">
-        <div class="flex flex-wrap">
-            <div class="container bg-white rounded-xl shadow-lg transform transition duration-500 p-7">
-                <div class="flex flex-wrap" id="wrapper-for-text-red">
-                    <div class="w-full">
-                        <ul class="flex mb-0 list-none flex-wrap pt-3 pb-4" id="day-tab-selector">
-                            <li class="-mb-px mr-2 mb-2 last:mr-0 flex-auto text-center">
-                                <a class="text-sm uppercase px-5 py-3 shadow-lg rounded block leading-normal text-red-600 bg-white border-b-4 border-red-600" data-tab-toggle="text-tab-day_1-red" onclick="changeActiveTab(event,'wrapper-for-text-red','red','text-tab-day_1-red')">
-                                    Wednesday, 01 December
-                                </a>
-                            </li>
-                            <li class="-mb-px mr-2 mb-2 last:mr-0 flex-auto text-center">
-                                <a class="text-sm uppercase px-5 py-3 shadow-lg rounded block leading-normal text-red-600 bg-white" data-tab-toggle="text-tab-day_2-red" onclick="changeActiveTab(event,'wrapper-for-text-red','red','text-tab-day_2-red')">
-                                    Thursday, 02 December
-                                </a>
-                            </li>
-                            <li class="-mb-px mr-2 mb-2 last:mr-0 flex-auto text-center">
-                                <a class="text-sm uppercase px-5 py-3 shadow-lg rounded block leading-normal text-red-600 bg-white" data-tab-toggle="text-tab-day_3-red" onclick="changeActiveTab(event,'wrapper-for-text-red','red','text-tab-day_3-red')">
-                                    Friday, 03 December
-                                </a>
-                            </li>
-                             <li class="-mb-px mr-2 mb-2 last:mr-0 flex-auto text-center">
-                                <a class="text-sm uppercase px-5 py-3 shadow-lg rounded block leading-normal text-red-600 bg-white" data-tab-toggle="text-tab-day_4-red" onclick="changeActiveTab(event,'wrapper-for-text-red','red','text-tab-day_4-red')">
-                                    Saturday, 04 December
-                                </a>
-                            </li>
-                        </ul>
-                        <hr class="border-2 m-auto w-2/5 mb-2">
-                        <div class="relative flex flex-col min-w-0 break-words bg-white w-full mb-6 shadow-lg rounded">
-                            <div class="px-4 py-5 flex-auto">
-                                <div class="tab-content tab-space">
-                                    <div class="block" data-tab-content="true" id="text-tab-day_1-red">
-                                        <p class="uppercase text-sm">7:00 am</p> <hr>
-                                        <div class="flex mb-0 flex-wrap pt-3 pb-4 flex-col md:flex-row activity">
-                                            <a href="/" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto beginner">
-                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #8b0000b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
-                                                    <div class="activity_time font-bold">
-                                                        9:00
-                                                        <div class="prompt font-normal text-sm">AM</div>
-                                                    </div> <br>
-                                                    <div class="activity_duration text-gray-50">30min</div>
-                                                </div>
-                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
-                                                    <div class="title">Exactly move trial occur stop else reduce continue</div>
-                                                    <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
-                                                    <div class="level text-sm" style="color: #8b0000b0;">Beginner</div>
-                                                </div>
-                                            </a>  
-                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto intermediate">
-                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #008b17b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
-                                                    <div class="activity_time font-bold">
-                                                        9:00
-                                                        <div class="prompt font-normal text-sm">AM</div>
-                                                    </div> <br>
-                                                    <div class="activity_duration text-gray-50">30min</div>
-                                                </div>
-                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
-                                                <div class="title">Exactly move trial occur stop else reduce continue</div>
-                                                <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
-                                                <div class="level text-sm" style="color: #008b17b0;">Intermediate</div>
-                                                </div>
-                                            </a> 
-                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto advance">
-                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #00098bb0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
-                                                    <div class="activity_time font-bold">
-                                                        9:00
-                                                        <div class="prompt font-normal text-sm">AM</div>
-                                                    </div> <br>
-                                                    <div class="activity_duration text-gray-50">30min</div>
-                                                </div>
-                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
-                                                <div class="title">Exactly move trial occur stop else reduce continue</div>
-                                                <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
-                                                <div class="level text-sm" style="color: #00098bb0;">Advance</div>
-                                                </div>
-                                            </a> 
-                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto normal">
-                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #020202b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
-                                                    <div class="activity_time font-bold">
-                                                        24:59
-                                                        <div class="prompt font-normal text-sm">AM</div>
-                                                    </div> <br>
-                                                    <div class="activity_duration text-gray-50">30min</div>
-                                                </div>
-                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
-                                                <div class="title">Exactly move trial occur stop else reduce continue</div>
-                                                <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
-                                                <div class="level text-sm" style="color: #020202b0;">Normal</div>
-                                                </div>
-
-                                            </a>
-                                        </div>
-                                        <p class="uppercase text-sm">7:30 am</p> <hr>
-                                        <div class="flex mb-0 flex-wrap pt-3 pb-4 flex-col md:flex-row activity">
-                                            <a href="/" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto beginner">
-                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #8b0000b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
-                                                    <div class="activity_time font-bold">
-                                                        9:00
-                                                        <div class="prompt font-normal text-sm">AM</div>
-                                                    </div> <br>
-                                                    <div class="activity_duration text-gray-50">30min</div>
-                                                </div>
-                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
-                                                    <div class="title">Exactly move trial occur stop else reduce continue</div>
-                                                    <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
-                                                    <div class="level text-sm" style="color: #8b0000b0;">Beginner</div>
-                                                </div>
-                                            </a>  
-                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto intermediate">
-                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #008b17b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
-                                                    <div class="activity_time font-bold">
-                                                        9:00
-                                                        <div class="prompt font-normal text-sm">AM</div>
-                                                    </div> <br>
-                                                    <div class="activity_duration text-gray-50">30min</div>
-                                                </div>
-                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
-                                                <div class="title">Exactly move trial occur stop else reduce continue</div>
-                                                <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
-                                                <div class="level text-sm" style="color: #008b17b0;">Intermediate</div>
-                                                </div>
-                                            </a> 
-                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto advance">
-                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #00098bb0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
-                                                    <div class="activity_time font-bold">
-                                                        9:00
-                                                        <div class="prompt font-normal text-sm">AM</div>
-                                                    </div> <br>
-                                                    <div class="activity_duration text-gray-50">30min</div>
-                                                </div>
-                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
-                                                <div class="title">Exactly move trial occur stop else reduce continue</div>
-                                                <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
-                                                <div class="level text-sm" style="color: #00098bb0;">Advance</div>
-                                                </div>
-                                            </a> 
-                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto normal">
-                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #020202b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
-                                                    <div class="activity_time font-bold">
-                                                        24:59
-                                                        <div class="prompt font-normal text-sm">AM</div>
-                                                    </div> <br>
-                                                    <div class="activity_duration text-gray-50">30min</div>
-                                                </div>
-                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
-                                                <div class="title">Exactly move trial occur stop else reduce continue</div>
-                                                <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
-                                                <div class="level text-sm" style="color: #020202b0;">Normal</div>
-                                                </div>
-
-                                            </a>
-                                        </div>
-
-                                    </div>
-                                    <div class="hidden" data-tab-content="true" id="text-tab-day_2-red">
-                                        <p>
-                                            Day 2 Schedule
-                                        </p>
-                                    </div>
-                                    <div class="hidden" data-tab-content="true" id="text-tab-day_3-red">
-                                        <p>
-                                            Day 3 Schedule
-                                        </p>
-                                    </div>
-                                    <div class="hidden" data-tab-content="true" id="text-tab-day_3-red">
-                                        <p>
-                                            Day 4 Schedule
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
+    <button id="up_button" style="position: fixed; bottom: 0; right: 0; z-index: 1000;"
+        class="hidden bg-red-400 text-white shadow-lg font-normal h-10 w-10 mb-8 rounded-full outline-none focus:outline-none mr-2">
+        <i class="fa fa-arrow-up"></i>
+    </button>    
+        
+    <p class="pb-16 bg-red-500"></p>
+    <section class="pb-20 bg-blueGray-200">
+        <p class="p-5 bg-transparent"></p>
+        <div class="container mx-auto">
+            <div class="flex flex-wrap">
+                <div class="container bg-white rounded-xl shadow-lg transform transition duration-500 p-3">
+                    <div class="program_info mb-6">
+                        <h5 class="text-center font-bold mb-2 underline">PROGRAM</h5>
+                        <p class="mx-7">
+                            FlaskCon 2021 will be held completely online. 
+                            Links to individual talks will be posted in the schedule below (soon). 
+                            The conference follows UTC time(+00:00). If you are in a different timezone, 
+                            view the schedule in your timezone and add it to your calendar.
+                            <br>
+                            With our streaming platform we will be able to run multiple tracks simultaneously 
+                            so that every Python enthusiast can find content matching their interest. 
+                            Register now to participate in our conference, our Discord channel, and join our workshops.
+                        </p>
                         </div>
-                    </div>
+
+                        <div class="timezone-selector mx-7 flex flex-col md:flex-row justify-between">
+                            <div class="mb-2">
+                                <label for="select-timezone" class="font-semibold">View schedule in your timezone:</label>
+                                <select class="rounded pr-8 mb-1" id="select-timezone">
+                                    {% if timezone == "UTC" %}
+                                        <option value="UTC" selected>UTC</option>
+                                        <option id="user-timezone"></option>
+                                    {% else %}
+                                        <option value="UTC">UTC</option>
+                                        <option id="user-timezone" selected></option>
+                                    {% endif %}
+                                    
+                                </select>
+                            </div>
+                            <div class="mb-2">
+                                <a href="#" id="btn-timezone" 
+                                class="bg-yellow-600 text-white px-3 py-3 rounded font-bold text-sm shadow hover:shadow-md outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150">
+                                    Add schedule to 📅 Calendar
+                                </a>
+                            </div>
+                            
+                        </div>
+                        <hr class="border-2 m-auto w-2/5 mb-3 mt-6">
+                            <div class="flex flex-wrap" id="wrapper-for-text-red">
+                                <div class="w-full">
+                                    <ul class="flex mb-0 list-none flex-wrap pt-3 pb-4" id="day-tab-selector">
+                                        {% set days = schedule.days | get_enum %}
+                                        {% for day_index, day in days %}
+                                            {% if day_index == 0 %}
+                                                <li class="-mb-px mr-2 mb-2 last:mr-0 flex-auto text-center">
+                                                    <a class="text-sm uppercase px-5 py-3 shadow-lg rounded block leading-normal text-red-600 bg-white border-b-4 border-red-600" data-tab-toggle="text-tab-day_{{ day_index + 1 }}-red" onclick="changeActiveTab(event,'wrapper-for-text-red','red','text-tab-day_{{ day_index + 1 }}-red')">
+                                                        {{ day.date.strftime("%A, %d %B") }}
+                                                    </a>
+                                                </li>
+                                            {% else %}
+                                                <li class="-mb-px mr-2 mb-2 last:mr-0 flex-auto text-center">
+                                                    <a class="text-sm uppercase px-5 py-3 shadow-lg rounded block leading-normal text-red-600 bg-white" data-tab-toggle="text-tab-day_{{ day_index + 1 }}-red" onclick="changeActiveTab(event,'wrapper-for-text-red','red','text-tab-day_{{ day_index + 1 }}-red')">
+                                                        {{ day.date.strftime("%A, %d %B") }}
+                                                    </a>
+                                                </li>
+                                            {% endif %}
+                                        {% endfor %}
+
+                                    </ul>
+
+
+                                    <div class="relative flex flex-col min-w-0 break-words bg-white w-full mb-6 shadow-lg rounded">
+                                        <div class="px-4 py-5 flex-auto">
+                                            <div class="tab-content tab-space">
+                                                {% set days = schedule.days | get_enum %}
+                                                {% for day_index, day in days %}
+                                                    {% if day_index == 0 %}
+                                                        <div
+                                                            class="block" data-tab-content="true" id="text-tab-day_{{ day_index + 1 }}-red">
+                                                            <!-- Call the get_time_indicators method which returns a Tuple with 2 elements and set it as a variable -->
+                                                            {% set time_indicators = day.get_time_indicators(timezone, 2021) %}
+                                                            <!-- The first element in the time_indicators Tuple is a list and the second element is a dictionary -->
+                                                            {% set indicators = time_indicators[0] %}
+                                                            {% set pair_indicators = time_indicators[1] %}
+                                                            {% for i in indicators %}
+                                                                {# 
+                                                                                                                        We loop through the indicators list and for each element in the list,
+                                                                                                                        we use the element to query our pair_indicators dictionary to retrieve the appropriate time intervals.
+                                                                                                                        
+                                                                                                                        We then call the get_sorted_activities_based_on_timezone method which returns a sorted list in ascending order.
+                                                                                                                        We set the returned list as a variable called activities and loop through it.
+                                                                                                                        For each element in the activities list, we check if the start_time is between a particular time interval.
+                                                                                                                        #}
+                                                                <p class="uppercase text-sm">{{ i.strftime("%I:%M %p") }}</p>
+                                                                <hr>
+                                                                    {% if i.time().strftime("%I:%M %p") == indicators[7].time().strftime("%I:%M %p") or i.time().strftime("%I:%M %p") == indicators[-1].time().strftime("%I:%M %p") %}
+                                                                        <div style="background-color: #5e5d5d; width: 5px; height: 5px; border-radius: 50%; margin: 10px 0 0 10px;"></div>
+                                                                        <div style="background-color: #5e5d5d; width: 5px; height: 5px; border-radius: 50%; margin: 10px 0 0 10px;"></div>
+                                                                        <div style="background-color: #5e5d5d; width: 5px; height: 5px; border-radius: 50%; margin: 10px 0 0 10px;"></div>
+                                                                        <div style="background-color: #5e5d5d; width: 5px; height: 5px; border-radius: 50%; margin: 10px 0 0 10px;"></div>
+                                                                    {% endif %}
+                                                                    <div class="flex mb-0 flex-wrap pt-3 pb-4 flex-col md:flex-row activity">
+                                                                        {% set time_interval = pair_indicators[i|string] %}
+                                                                        {% set activities = day.get_sorted_activities_based_on_timezone(timezone) %}
+                                                                        {% for activity_ in activities %}
+                                                                            {% if time_interval[0].time() <= activity_[1].time() < time_interval[1].time() %}
+                                                                                {% set activity = activity_[0] %}
+                                                                                {% if activity.type == 'talk' %}
+                                                                                    {% set talk = activity.get_talk() %}
+                                                                                    {% if talk.level == "beginner" %}
+                                                                                        <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto beginner">
+                                                                                            <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #8b0000b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                                                                <div class="activity_time font-bold">
+                                                                                                    {{ activity_[1].strftime("%I:%M") }}
+                                                                                                    <div class="prompt font-normal text-sm">{{ activity_[1].strftime("%p") }}</div>
+                                                                                                </div>
+                                                                                                <br>
+                                                                                                    <div class="activity_duration text-gray-50">{{ activity_[2] }}</div>
+                                                                                                </div>
+                                                                                                <div class="border rounded col-span-3 p-2 flex flex-col justify-between" style="border-top-left-radius: 0; border-bottom-left-radius: 0; border-color: #cccccc;">
+                                                                                                    <div class="title mb-3">{{ talk.title | truncate(60, true) }}</div>
+                                                                                                    <div class="author text-gray-500 text-sm capitalize">
+                                                                                                        {% for author in talk.author_list.authors %}
+                                                                                                            {{ author.first_name }}
+                                                                                                            {{ author.last_name }}
+                                                                                                        {% endfor %}
+                                                                                                    </div>
+                                                                                                    <br>
+                                                                                                        <div class="level text-sm capitalize self-end" style="color: #8b0000b0;">{{ talk.level }}</div>
+                                                                                                    </div>
+                                                                                                </a>
+                                                                                            {% endif %}
+                                                                                            {% if talk.level == "intermediate" %}
+                                                                                                <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto intermediate">
+                                                                                                    <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #008b17b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                                                                        <div class="activity_time font-bold">
+                                                                                                            {{ activity_[1].strftime("%I:%M") }}
+                                                                                                            <div class="prompt font-normal text-sm">{{ activity_[1].strftime("%p") }}</div>
+                                                                                                        </div>
+                                                                                                        <br>
+                                                                                                            <div class="activity_duration text-gray-50">{{ activity_[2] }}</div>
+                                                                                                        </div>
+                                                                                                        <div class="border rounded col-span-3 p-2 flex flex-col justify-between" style="border-top-left-radius: 0; border-bottom-left-radius: 0; border-color: #cccccc;">
+                                                                                                            <div class="title mb-3">{{ talk.title | truncate(60, true) }}</div>
+                                                                                                            <div class="author text-gray-500 text-sm capitalize">
+                                                                                                                {% for author in talk.author_list.authors %}
+                                                                                                                    {{ author.first_name }}
+                                                                                                                    {{ author.last_name }}
+                                                                                                                {% endfor %}
+                                                                                                            </div>
+                                                                                                            <br>
+                                                                                                                <div class="level text-sm capitalize self-end" style="color: #008b17b0;">{{ talk.level }}</div>
+                                                                                                            </div>
+                                                                                                        </a>
+                                                                                                    {% endif %}
+                                                                                                    {% if talk.level == "advanced" %}
+                                                                                                        <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto advance">
+                                                                                                            <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #00098bb0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                                                                                <div class="activity_time font-bold">
+                                                                                                                    {{ activity_[1].strftime("%I:%M") }}
+                                                                                                                    <div class="prompt font-normal text-sm">{{ activity_[1].strftime("%p") }}</div>
+                                                                                                                </div>
+                                                                                                                <br>
+                                                                                                                    <div class="activity_duration text-gray-50">{{ activity_[2] }}</div>
+                                                                                                                </div>
+                                                                                                                <div class="border rounded col-span-3 p-2 flex flex-col justify-between" style="border-top-left-radius: 0; border-bottom-left-radius: 0; border-color: #cccccc;">
+                                                                                                                    <div class="title mb-3">{{ talk.title | truncate(60, true) }}</div>
+                                                                                                                    <div class="author text-gray-500 text-sm capitalize">
+                                                                                                                        {% for author in talk.author_list.authors %}
+                                                                                                                            {{ author.first_name }}
+                                                                                                                            {{ author.last_name }}
+                                                                                                                        {% endfor %}
+                                                                                                                    </div>
+                                                                                                                    <br>
+                                                                                                                        <div class="level text-sm capitalize self-end" style="color: #00098bb0;">{{ talk.level }}</div>
+                                                                                                                    </div>
+                                                                                                                </a>
+                                                                                                            {% endif %}
+                                                                                                        {% else %}
+                                                                                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto normal">
+                                                                                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #020202b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                                                                                    <div class="activity_time font-bold">
+                                                                                                                        {{ activity_[1].strftime("%I:%M") }}
+                                                                                                                        <div class="prompt font-normal text-sm">{{ activity_[1].strftime("%p") }}</div>
+                                                                                                                    </div>
+                                                                                                                    <br>
+                                                                                                                        <div class="activity_duration text-gray-50">{{ activity_[2] }}</div>
+                                                                                                                    </div>
+                                                                                                                    <div class="border rounded col-span-3 p-2 flex flex-col justify-between" style="border-top-left-radius: 0; border-bottom-left-radius: 0; border-color: #cccccc;">
+                                                                                                                        <div class="title">{{ activity.text | truncate(60, true) }}</div>
+                                                                                                                        <br>
+                                                                                                                            <div class="level text-sm self-end" style="color: #020202b0;">Normal</div>
+                                                                                                                        </div>
+                                                                                                                    </a>
+                                                                                                                {% endif %}
+                                                                                                            {% endif %}
+                                                                                                        {% endfor %}
+                                                                                                    </div>
+                                                                                                {% endfor %}
+                                                                                            </div>
+                                                                                        {% else %}
+                                                                                            <div
+                                                                                                class="hidden" data-tab-content="true" id="text-tab-day_{{ day_index + 1 }}-red">
+                                                                                                <!-- Call the get_time_indicators method which returns a Tuple with 2 elements and set it as a variable -->
+                                                                                                {% set time_indicators = day.get_time_indicators(timezone, 2021) %}
+                                                                                                <!-- The first element in the time_indicators Tuple is a list and the second element is a dictionary -->
+                                                                                                {% set indicators = time_indicators[0] %}
+                                                                                                {% set pair_indicators = time_indicators[1] %}
+                                                                                                {% for i in indicators %}
+                                                                                                    {# 
+                                                                                                                                                            We loop through the indicators list and for each element in the list,
+                                                                                                                                                            we use the element to query our pair_indicators dictionary to retrieve the appropriate time intervals.
+                                                                                                                                                            
+                                                                                                                                                            We then call the get_sorted_activities_based_on_timezone method which returns a sorted list in ascending order.
+                                                                                                                                                            We set the returned list as a variable called activities and loop through it.
+                                                                                                                                                            For each element in the activities list, we check if the start_time is between a particular time interval.
+                                                                                                                                                            #}
+                                                                                                    <p class="uppercase text-sm">{{ i.strftime("%I:%M %p") }}</p>
+                                                                                                    <hr>
+                                                                                                        {% if i.time().strftime("%I:%M %p") == indicators[7].time().strftime("%I:%M %p") or i.time().strftime("%I:%M %p") == indicators[-1].time().strftime("%I:%M %p") %}
+                                                                                                            <div style="background-color: #5e5d5d; width: 5px; height: 5px; border-radius: 50%; margin: 10px 0 0 10px;"></div>
+                                                                                                            <div style="background-color: #5e5d5d; width: 5px; height: 5px; border-radius: 50%; margin: 10px 0 0 10px;"></div>
+                                                                                                            <div style="background-color: #5e5d5d; width: 5px; height: 5px; border-radius: 50%; margin: 10px 0 0 10px;"></div>
+                                                                                                            <div style="background-color: #5e5d5d; width: 5px; height: 5px; border-radius: 50%; margin: 10px 0 0 10px;"></div>
+                                                                                                        {% endif %}
+                                                                                                        <div class="flex mb-0 flex-wrap pt-3 pb-4 flex-col md:flex-row activity">
+                                                                                                            {% set time_interval = pair_indicators[i|string] %}
+                                                                                                            {% set activities = day.get_sorted_activities_based_on_timezone(timezone) %}
+                                                                                                            {% for activity_ in activities %}
+                                                                                                                {% if time_interval[0].time() <= activity_[1].time() < time_interval[1].time() %}
+                                                                                                                    {% set activity = activity_[0] %}
+                                                                                                                    {% if activity.type == 'talk' %}
+                                                                                                                        {% set talk = activity.get_talk() %}
+                                                                                                                        {% if talk.level == "beginner" %}
+                                                                                                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto beginner">
+                                                                                                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #8b0000b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                                                                                                    <div class="activity_time font-bold">
+                                                                                                                                        {{ activity_[1].strftime("%I:%M") }}
+                                                                                                                                        <div class="prompt font-normal text-sm">{{ activity_[1].strftime("%p") }}</div>
+                                                                                                                                    </div>
+                                                                                                                                    <br>
+                                                                                                                                        <div class="activity_duration text-gray-50">{{ activity_[2] }}</div>
+                                                                                                                                    </div>
+                                                                                                                                    <div class="border rounded col-span-3 p-2 flex flex-col justify-between" style="border-top-left-radius: 0; border-bottom-left-radius: 0; border-color: #cccccc;">
+                                                                                                                                        <div class="title mb-3">{{ talk.title | truncate(60, true) }}</div>
+                                                                                                                                        <div class="author text-gray-500 text-sm capitalize">
+                                                                                                                                            {% for author in talk.author_list.authors %}
+                                                                                                                                                {{ author.first_name }}
+                                                                                                                                                {{ author.last_name }}
+                                                                                                                                            {% endfor %}
+                                                                                                                                        </div>
+                                                                                                                                        <br>
+                                                                                                                                            <div class="level text-sm capitalize self-end" style="color: #8b0000b0;">{{ talk.level }}</div>
+                                                                                                                                        </div>
+                                                                                                                                    </a>
+                                                                                                                                {% endif %}
+                                                                                                                                {% if talk.level == "intermediate" %}
+                                                                                                                                    <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto intermediate">
+                                                                                                                                        <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #008b17b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                                                                                                            <div class="activity_time font-bold">
+                                                                                                                                                {{ activity_[1].strftime("%I:%M") }}
+                                                                                                                                                <div class="prompt font-normal text-sm">{{ activity_[1].strftime("%p") }}</div>
+                                                                                                                                            </div>
+                                                                                                                                            <br>
+                                                                                                                                                <div class="activity_duration text-gray-50">{{ activity_[2] }}</div>
+                                                                                                                                            </div>
+                                                                                                                                            <div class="border rounded col-span-3 p-2 flex flex-col justify-between" style="border-top-left-radius: 0; border-bottom-left-radius: 0; border-color: #cccccc;">
+                                                                                                                                                <div class="title mb-3">{{ talk.title | truncate(60, true) }}</div>
+                                                                                                                                                <div class="author text-gray-500 text-sm capitalize">
+                                                                                                                                                    {% for author in talk.author_list.authors %}
+                                                                                                                                                        {{ author.first_name }}
+                                                                                                                                                        {{ author.last_name }}
+                                                                                                                                                    {% endfor %}
+                                                                                                                                                </div>
+                                                                                                                                                <br>
+                                                                                                                                                    <div class="level text-sm capitalize self-end" style="color: #008b17b0;">{{ talk.level }}</div>
+                                                                                                                                                </div>
+                                                                                                                                            </a>
+                                                                                                                                        {% endif %}
+                                                                                                                                        {% if talk.level == "advanced" %}
+                                                                                                                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto advance">
+                                                                                                                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #00098bb0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                                                                                                                    <div class="activity_time font-bold">
+                                                                                                                                                        {{ activity_[1].strftime("%I:%M") }}
+                                                                                                                                                        <div class="prompt font-normal text-sm">{{ activity_[1].strftime("%p") }}</div>
+                                                                                                                                                    </div>
+                                                                                                                                                    <br>
+                                                                                                                                                        <div class="activity_duration text-gray-50">{{ activity_[2] }}</div>
+                                                                                                                                                    </div>
+                                                                                                                                                    <div class="border rounded col-span-3 p-2 flex flex-col justify-between" style="border-top-left-radius: 0; border-bottom-left-radius: 0; border-color: #cccccc;">
+                                                                                                                                                        <div class="title mb-3">{{ talk.title | truncate(60, true) }}</div>
+                                                                                                                                                        <div class="author text-gray-500 text-sm capitalize">
+                                                                                                                                                            {% for author in talk.author_list.authors %}
+                                                                                                                                                                {{ author.first_name }}
+                                                                                                                                                                {{ author.last_name }}
+                                                                                                                                                            {% endfor %}
+                                                                                                                                                        </div>
+                                                                                                                                                        <br>
+                                                                                                                                                            <div class="level text-sm capitalize self-end" style="color: #00098bb0;">{{ talk.level }}</div>
+                                                                                                                                                        </div>
+                                                                                                                                                    </a>
+                                                                                                                                                {% endif %}
+                                                                                                                                            {% else %}
+                                                                                                                                                <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto normal">
+                                                                                                                                                    <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #020202b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                                                                                                                        <div class="activity_time font-bold">
+                                                                                                                                                            {{ activity_[1].strftime("%I:%M") }}
+                                                                                                                                                            <div class="prompt font-normal text-sm">{{ activity_[1].strftime("%p") }}</div>
+                                                                                                                                                        </div>
+                                                                                                                                                        <br>
+                                                                                                                                                            <div class="activity_duration text-gray-50">{{ activity_[2] }}</div>
+                                                                                                                                                        </div>
+                                                                                                                                                        <div class="border rounded col-span-3 p-2 flex flex-col justify-between" style="border-top-left-radius: 0; border-bottom-left-radius: 0; border-color: #cccccc;">
+                                                                                                                                                            <div class="title">{{ activity.text | truncate(60, true) }}</div>
+                                                                                                                                                            <br>
+                                                                                                                                                                <div class="level text-sm self-end" style="color: #020202b0;">Normal</div>
+                                                                                                                                                            </div>
+                                                                                                                                                        </a>
+                                                                                                                                                    {% endif %}
+                                                                                                                                                {% endif %}
+                                                                                                                                            {% endfor %}
+                                                                                                                                        </div>
+                                                                                                                                    {% endfor %}
+                                                                                                                                </div>
+                                                                                                                            {% endif %}
+                                                                                                                        {% endfor %}
+
+                                                                                                                    </div>
+                                                                                                                </div>
+                                                                                                            </div>
+
+                                                                                                        </div>
+                                                                                                    </div>
                 </div>
             </div>
         </div>
-    </div>
-</section>
-<script type="text/javascript">
-function changeActiveTab(event, wrapperID, color, tabID) {
-    let tabsWrapper = document.getElementById(wrapperID);
-    let tabsAnchors = tabsWrapper.querySelectorAll("[data-tab-toggle]");
-    let tabsContent = tabsWrapper.querySelectorAll("[data-tab-content]");
-    for (let i = 0; i < tabsAnchors.length; i++) {
-        if (tabsAnchors[i].getAttribute("data-tab-toggle") === tabID) {
-            tabsAnchors[i].classList.add("border-" + color + "-600");
-            tabsAnchors[i].classList.add("border-b-4");
-            tabsContent[i].classList.remove("hidden");
-            tabsContent[i].classList.add("block");
-        } else {
-            tabsAnchors[i].classList.remove("border-" + color + "-600");
-            tabsAnchors[i].classList.remove("border-b-4");
-            tabsContent[i].classList.add("hidden");
-            tabsContent[i].classList.remove("block");
+    </section>
+
+        
+
+    <script type="text/javascript">
+        function changeActiveTab(event, wrapperID, color, tabID) {
+            let tabsWrapper = document.getElementById(wrapperID);
+            let tabsAnchors = tabsWrapper.querySelectorAll("[data-tab-toggle]");
+            let tabsContent = tabsWrapper.querySelectorAll("[data-tab-content]");
+            for (let i = 0; i < tabsAnchors.length; i++) {
+                if (tabsAnchors[i].getAttribute("data-tab-toggle") === tabID) {
+                    tabsAnchors[i].classList.add("border-" + color + "-600");
+                    tabsAnchors[i].classList.add("border-b-4");
+                    tabsContent[i].classList.remove("hidden");
+                    tabsContent[i].classList.add("block");
+                } else {
+                    tabsAnchors[i].classList.remove("border-" + color + "-600");
+                    tabsAnchors[i].classList.remove("border-b-4");
+                    tabsContent[i].classList.add("hidden");
+                    tabsContent[i].classList.remove("block");
+                }
+            }
         }
-    }
-}
-</script>
 
-
+    </script>
+    <script src="{{ url_for('static', filename='js/custom.js') }}"></script>
 
 {% endblock %}

--- a/traveller/static/themes/front/conftheme/2021/parts/schedule_2.html
+++ b/traveller/static/themes/front/conftheme/2021/parts/schedule_2.html
@@ -1,0 +1,263 @@
+{% extends 'conftheme/2021/parts/base.html'%}
+{% block head %}
+<title>Schedule | FlaskCon</title>
+<style type="text/css">
+a {
+    word-wrap: break-word;
+}
+
+.modal-body {
+    height: 500px;
+    overflow-y: scroll;
+}
+#day-tab-selector{
+    flex-direction: row;
+  }
+
+@media (max-width: 640px) {
+  .day_tools {
+    display: block;
+    margin-top: 5px;
+  }
+  #day-tab-selector{
+    flex-direction: column;
+  }
+  
+}
+@media (max-width: 1280px) {
+    .activity a{
+        max-width: 100%;
+    }
+}
+.activity a.beginner:hover{
+    border: 1px solid #8b0000b0;
+    border-radius: 0.25rem;
+}
+.activity a.intermediate:hover{
+    border: 1px solid #008b17b0;
+    border-radius: 0.25rem;
+}
+.activity a.advance:hover{
+    border: 1px solid #00098bb0;
+    border-radius: 0.25rem;
+}
+.activity a.normal:hover{
+    border: 1px solid #020202b0;
+    border-radius: 0.25rem;
+}
+
+
+@media (max-width: 380px) {
+  .activity_tools {
+    display: block;
+    margin-top: 3px;
+  }
+}
+</style>
+{% endblock %}
+{% block body %}
+<p class="pb-16 bg-red-500"></p>
+<section class="pb-20 bg-blueGray-200">
+    <p class="p-5 bg-transparent"></p>
+    <div class="container mx-auto px-4">
+        <div class="flex flex-wrap">
+            <div class="container bg-white rounded-xl shadow-lg transform transition duration-500 p-7">
+                <div class="flex flex-wrap" id="wrapper-for-text-red">
+                    <div class="w-full">
+                        <ul class="flex mb-0 list-none flex-wrap pt-3 pb-4" id="day-tab-selector">
+                            <li class="-mb-px mr-2 mb-2 last:mr-0 flex-auto text-center">
+                                <a class="text-sm uppercase px-5 py-3 shadow-lg rounded block leading-normal text-red-600 bg-white border-b-4 border-red-600" data-tab-toggle="text-tab-day_1-red" onclick="changeActiveTab(event,'wrapper-for-text-red','red','text-tab-day_1-red')">
+                                    Wednesday, 01 December
+                                </a>
+                            </li>
+                            <li class="-mb-px mr-2 mb-2 last:mr-0 flex-auto text-center">
+                                <a class="text-sm uppercase px-5 py-3 shadow-lg rounded block leading-normal text-red-600 bg-white" data-tab-toggle="text-tab-day_2-red" onclick="changeActiveTab(event,'wrapper-for-text-red','red','text-tab-day_2-red')">
+                                    Thursday, 02 December
+                                </a>
+                            </li>
+                            <li class="-mb-px mr-2 mb-2 last:mr-0 flex-auto text-center">
+                                <a class="text-sm uppercase px-5 py-3 shadow-lg rounded block leading-normal text-red-600 bg-white" data-tab-toggle="text-tab-day_3-red" onclick="changeActiveTab(event,'wrapper-for-text-red','red','text-tab-day_3-red')">
+                                    Friday, 03 December
+                                </a>
+                            </li>
+                             <li class="-mb-px mr-2 mb-2 last:mr-0 flex-auto text-center">
+                                <a class="text-sm uppercase px-5 py-3 shadow-lg rounded block leading-normal text-red-600 bg-white" data-tab-toggle="text-tab-day_4-red" onclick="changeActiveTab(event,'wrapper-for-text-red','red','text-tab-day_4-red')">
+                                    Saturday, 04 December
+                                </a>
+                            </li>
+                        </ul>
+                        <hr class="border-2 m-auto w-2/5 mb-2">
+                        <div class="relative flex flex-col min-w-0 break-words bg-white w-full mb-6 shadow-lg rounded">
+                            <div class="px-4 py-5 flex-auto">
+                                <div class="tab-content tab-space">
+                                    <div class="block" data-tab-content="true" id="text-tab-day_1-red">
+                                        <p class="uppercase text-sm">7:00 am</p> <hr>
+                                        <div class="flex mb-0 flex-wrap pt-3 pb-4 flex-col md:flex-row activity">
+                                            <a href="/" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto beginner">
+                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #8b0000b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                    <div class="activity_time font-bold">
+                                                        9:00
+                                                        <div class="prompt font-normal text-sm">AM</div>
+                                                    </div> <br>
+                                                    <div class="activity_duration text-gray-50">30min</div>
+                                                </div>
+                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
+                                                    <div class="title">Exactly move trial occur stop else reduce continue</div>
+                                                    <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
+                                                    <div class="level text-sm" style="color: #8b0000b0;">Beginner</div>
+                                                </div>
+                                            </a>  
+                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto intermediate">
+                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #008b17b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                    <div class="activity_time font-bold">
+                                                        9:00
+                                                        <div class="prompt font-normal text-sm">AM</div>
+                                                    </div> <br>
+                                                    <div class="activity_duration text-gray-50">30min</div>
+                                                </div>
+                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
+                                                <div class="title">Exactly move trial occur stop else reduce continue</div>
+                                                <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
+                                                <div class="level text-sm" style="color: #008b17b0;">Intermediate</div>
+                                                </div>
+                                            </a> 
+                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto advance">
+                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #00098bb0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                    <div class="activity_time font-bold">
+                                                        9:00
+                                                        <div class="prompt font-normal text-sm">AM</div>
+                                                    </div> <br>
+                                                    <div class="activity_duration text-gray-50">30min</div>
+                                                </div>
+                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
+                                                <div class="title">Exactly move trial occur stop else reduce continue</div>
+                                                <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
+                                                <div class="level text-sm" style="color: #00098bb0;">Advance</div>
+                                                </div>
+                                            </a> 
+                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto normal">
+                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #020202b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                    <div class="activity_time font-bold">
+                                                        24:59
+                                                        <div class="prompt font-normal text-sm">AM</div>
+                                                    </div> <br>
+                                                    <div class="activity_duration text-gray-50">30min</div>
+                                                </div>
+                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
+                                                <div class="title">Exactly move trial occur stop else reduce continue</div>
+                                                <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
+                                                <div class="level text-sm" style="color: #020202b0;">Normal</div>
+                                                </div>
+
+                                            </a>
+                                        </div>
+                                        <p class="uppercase text-sm">7:30 am</p> <hr>
+                                        <div class="flex mb-0 flex-wrap pt-3 pb-4 flex-col md:flex-row activity">
+                                            <a href="/" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto beginner">
+                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #8b0000b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                    <div class="activity_time font-bold">
+                                                        9:00
+                                                        <div class="prompt font-normal text-sm">AM</div>
+                                                    </div> <br>
+                                                    <div class="activity_duration text-gray-50">30min</div>
+                                                </div>
+                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
+                                                    <div class="title">Exactly move trial occur stop else reduce continue</div>
+                                                    <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
+                                                    <div class="level text-sm" style="color: #8b0000b0;">Beginner</div>
+                                                </div>
+                                            </a>  
+                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto intermediate">
+                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #008b17b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                    <div class="activity_time font-bold">
+                                                        9:00
+                                                        <div class="prompt font-normal text-sm">AM</div>
+                                                    </div> <br>
+                                                    <div class="activity_duration text-gray-50">30min</div>
+                                                </div>
+                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
+                                                <div class="title">Exactly move trial occur stop else reduce continue</div>
+                                                <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
+                                                <div class="level text-sm" style="color: #008b17b0;">Intermediate</div>
+                                                </div>
+                                            </a> 
+                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto advance">
+                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #00098bb0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                    <div class="activity_time font-bold">
+                                                        9:00
+                                                        <div class="prompt font-normal text-sm">AM</div>
+                                                    </div> <br>
+                                                    <div class="activity_duration text-gray-50">30min</div>
+                                                </div>
+                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
+                                                <div class="title">Exactly move trial occur stop else reduce continue</div>
+                                                <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
+                                                <div class="level text-sm" style="color: #00098bb0;">Advance</div>
+                                                </div>
+                                            </a> 
+                                            <a href="#" class="max-w-xs grid grid-cols-3 mr-2 mb-2 flex-auto normal">
+                                                <div class="col-end-1 text-white text-right rounded p-2" style="background-color: #020202b0; border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                                    <div class="activity_time font-bold">
+                                                        24:59
+                                                        <div class="prompt font-normal text-sm">AM</div>
+                                                    </div> <br>
+                                                    <div class="activity_duration text-gray-50">30min</div>
+                                                </div>
+                                                <div class="border rounded col-span-3 p-2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">
+                                                <div class="title">Exactly move trial occur stop else reduce continue</div>
+                                                <div class="author text-gray-500 text-sm">Randy Duodu</div> <br>
+                                                <div class="level text-sm" style="color: #020202b0;">Normal</div>
+                                                </div>
+
+                                            </a>
+                                        </div>
+
+                                    </div>
+                                    <div class="hidden" data-tab-content="true" id="text-tab-day_2-red">
+                                        <p>
+                                            Day 2 Schedule
+                                        </p>
+                                    </div>
+                                    <div class="hidden" data-tab-content="true" id="text-tab-day_3-red">
+                                        <p>
+                                            Day 3 Schedule
+                                        </p>
+                                    </div>
+                                    <div class="hidden" data-tab-content="true" id="text-tab-day_3-red">
+                                        <p>
+                                            Day 4 Schedule
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+<script type="text/javascript">
+function changeActiveTab(event, wrapperID, color, tabID) {
+    let tabsWrapper = document.getElementById(wrapperID);
+    let tabsAnchors = tabsWrapper.querySelectorAll("[data-tab-toggle]");
+    let tabsContent = tabsWrapper.querySelectorAll("[data-tab-content]");
+    for (let i = 0; i < tabsAnchors.length; i++) {
+        if (tabsAnchors[i].getAttribute("data-tab-toggle") === tabID) {
+            tabsAnchors[i].classList.add("border-" + color + "-600");
+            tabsAnchors[i].classList.add("border-b-4");
+            tabsContent[i].classList.remove("hidden");
+            tabsContent[i].classList.add("block");
+        } else {
+            tabsAnchors[i].classList.remove("border-" + color + "-600");
+            tabsAnchors[i].classList.remove("border-b-4");
+            tabsContent[i].classList.add("hidden");
+            tabsContent[i].classList.remove("block");
+        }
+    }
+}
+</script>
+
+
+
+{% endblock %}


### PR DESCRIPTION
Tasks handled in this PR:

- [x] Added option on the schedule page to show conference schedule in your own timezone.
- [x] Ensured activities are well arranged under their respective days and times.
- [x] Added talk duration field to the submit talk form.
- [x] Integrated the backend into the frontend design.
- [x] Made the activity cards a hyperlink so that when you click on an activity it takes you to a page that shows the full details about an activity
- [x] Added check to ensure both activity start and end times are between 09:00 to 18:00 and to ensure the minute hand for a start or end time is either o'clock or 30 minutes. Eg: A valid value for start will be 11:00 or 11:30

Factors that were considered in implementing this feature:
- The start and end times for a conference day are 09:00 am to 06:00 pm, respectively.
- The duration of an activity is derived from the end and start times of a talk which the user provides when submitting a talk
- Tracks are not implemented so the activities are arranged using the time they fall under and their level.
- Ability to export schedules in the iCal calendar would be added soon.
- Wrote the code in Python so I used the zoneinfo module to handle timezones details but added a backport for Python 3.6+ < 3.9 versions.

Kindly let me know if you encounter any errors.

